### PR TITLE
Add custom annotation model example

### DIFF
--- a/Examples.xcodeproj/project.pbxproj
+++ b/Examples.xcodeproj/project.pbxproj
@@ -22,6 +22,9 @@
 		961962D51C583FDC002D3DAB /* ExamplesContainerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 961962D41C583FDC002D3DAB /* ExamplesContainerViewController.m */; };
 		96466ACA1C9323D9009CF4AB /* CustomCalloutViewExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96466AC91C9323D9009CF4AB /* CustomCalloutViewExample.swift */; };
 		96466AD11C932EF5009CF4AB /* CustomCalloutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96466AD01C932EF5009CF4AB /* CustomCalloutView.swift */; };
+		9678E3EE1CEF58DA00F21AE2 /* CustomAnnotationModelExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 9678E3ED1CEF58DA00F21AE2 /* CustomAnnotationModelExample.m */; };
+		9678E3F01CEF591000F21AE2 /* CustomAnnotationModelExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9678E3EF1CEF591000F21AE2 /* CustomAnnotationModelExample.swift */; };
+		9678E3F41CEFA9B500F21AE2 /* CustomAnnotationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9678E3F31CEFA9B500F21AE2 /* CustomAnnotationModels.swift */; };
 		968247031C5BDCBB00494AB8 /* CustomRasterStyleExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 968247021C5BDCBB00494AB8 /* CustomRasterStyleExample.m */; };
 		968247051C5BDDC600494AB8 /* CustomRasterStyleExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 968247041C5BDDC600494AB8 /* CustomRasterStyleExample.swift */; };
 		968247081C5BEBDC00494AB8 /* SatelliteStyleExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 968247071C5BEBDC00494AB8 /* SatelliteStyleExample.m */; };
@@ -109,6 +112,11 @@
 		961962D41C583FDC002D3DAB /* ExamplesContainerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ExamplesContainerViewController.m; sourceTree = "<group>"; };
 		96466AC91C9323D9009CF4AB /* CustomCalloutViewExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CustomCalloutViewExample.swift; path = Examples/Swift/CustomCalloutViewExample.swift; sourceTree = SOURCE_ROOT; };
 		96466AD01C932EF5009CF4AB /* CustomCalloutView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CustomCalloutView.swift; path = Examples/Swift/CustomCalloutView.swift; sourceTree = SOURCE_ROOT; };
+		9678E3EC1CEF58DA00F21AE2 /* CustomAnnotationModelExample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomAnnotationModelExample.h; sourceTree = "<group>"; };
+		9678E3ED1CEF58DA00F21AE2 /* CustomAnnotationModelExample.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CustomAnnotationModelExample.m; sourceTree = "<group>"; };
+		9678E3EF1CEF591000F21AE2 /* CustomAnnotationModelExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CustomAnnotationModelExample.swift; path = Examples/Swift/CustomAnnotationModelExample.swift; sourceTree = SOURCE_ROOT; };
+		9678E3F21CEF616700F21AE2 /* CustomAnnotationModels.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomAnnotationModels.h; sourceTree = "<group>"; };
+		9678E3F31CEFA9B500F21AE2 /* CustomAnnotationModels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CustomAnnotationModels.swift; path = Examples/Swift/CustomAnnotationModels.swift; sourceTree = SOURCE_ROOT; };
 		968247011C5BDCBB00494AB8 /* CustomRasterStyleExample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CustomRasterStyleExample.h; path = Examples/ObjectiveC/CustomRasterStyleExample.h; sourceTree = SOURCE_ROOT; };
 		968247021C5BDCBB00494AB8 /* CustomRasterStyleExample.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CustomRasterStyleExample.m; path = Examples/ObjectiveC/CustomRasterStyleExample.m; sourceTree = SOURCE_ROOT; };
 		968247041C5BDDC600494AB8 /* CustomRasterStyleExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CustomRasterStyleExample.swift; path = Examples/Swift/CustomRasterStyleExample.swift; sourceTree = SOURCE_ROOT; };
@@ -264,6 +272,7 @@
 		9682472D1C5C226D00494AB8 /* Headers */ = {
 			isa = PBXGroup;
 			children = (
+				9678E3EC1CEF58DA00F21AE2 /* CustomAnnotationModelExample.h */,
 				968247111C5C0F0F00494AB8 /* CalloutDelegateUsageExample.h */,
 				968247251C5C1DC700494AB8 /* CameraAnimationExample.h */,
 				96A2A1D01C8CA74B0059441E /* CustomCalloutView.h */,
@@ -292,6 +301,10 @@
 				968247141C5C102B00494AB8 /* CalloutDelegateUsageExample.swift */,
 				968247261C5C1DC700494AB8 /* CameraAnimationExample.m */,
 				968247231C5C1D9500494AB8 /* CameraAnimationExample.swift */,
+				9678E3ED1CEF58DA00F21AE2 /* CustomAnnotationModelExample.m */,
+				9678E3EF1CEF591000F21AE2 /* CustomAnnotationModelExample.swift */,
+				9678E3F21CEF616700F21AE2 /* CustomAnnotationModels.h */,
+				9678E3F31CEFA9B500F21AE2 /* CustomAnnotationModels.swift */,
 				96A2A1D11C8CA74B0059441E /* CustomCalloutView.m */,
 				96466AD01C932EF5009CF4AB /* CustomCalloutView.swift */,
 				96A2A1CE1C8CA16C0059441E /* CustomCalloutViewExample.m */,
@@ -465,6 +478,7 @@
 				961962941C581700002D3DAB /* AppDelegate.m in Sources */,
 				968247171C5C10B100494AB8 /* DrawingAGeoJSONLineExample.swift in Sources */,
 				9691AAA71C5AAD8F006A58C6 /* CustomStyleExample.m in Sources */,
+				9678E3EE1CEF58DA00F21AE2 /* CustomAnnotationModelExample.m in Sources */,
 				961962D21C5821A9002D3DAB /* ExamplesTableViewController.m in Sources */,
 				968247201C5C1C0400494AB8 /* DrawingAPolygonExample.m in Sources */,
 				96A2A1D21C8CA74B0059441E /* CustomCalloutView.m in Sources */,
@@ -473,6 +487,7 @@
 				968247031C5BDCBB00494AB8 /* CustomRasterStyleExample.m in Sources */,
 				9682472A1C5C1FF800494AB8 /* PointConversionExample.m in Sources */,
 				96466ACA1C9323D9009CF4AB /* CustomCalloutViewExample.swift in Sources */,
+				9678E3F41CEFA9B500F21AE2 /* CustomAnnotationModels.swift in Sources */,
 				96D432041C84B62A007D09D1 /* DrawingACustomMarkerExample.swift in Sources */,
 				961962911C581700002D3DAB /* main.m in Sources */,
 				968247131C5C0F0F00494AB8 /* CalloutDelegateUsageExample.m in Sources */,
@@ -481,6 +496,7 @@
 				9682472C1C5C20F900494AB8 /* PointConversionExample.swift in Sources */,
 				9691AAA81C5AAD8F006A58C6 /* DefaultStylesExample.m in Sources */,
 				9682470A1C5BEE4D00494AB8 /* SatelliteStyleExample.swift in Sources */,
+				9678E3F01CEF591000F21AE2 /* CustomAnnotationModelExample.swift in Sources */,
 				968247081C5BEBDC00494AB8 /* SatelliteStyleExample.m in Sources */,
 				96115A681CAD4E1C000963B8 /* OfflinePackExample.m in Sources */,
 				9682471A1C5C115000494AB8 /* DrawingAGeoJSONLineExample.m in Sources */,

--- a/Examples/Examples.h
+++ b/Examples/Examples.h
@@ -17,6 +17,7 @@
 
 extern NSString *const MBXExampleCalloutDelegateUsage;
 extern NSString *const MBXExampleCameraAnimation;
+extern NSString *const MBXExampleCustomAnnotationModel;
 extern NSString *const MBXExampleCustomCalloutView;
 extern NSString *const MBXExampleCustomRasterStyle;
 extern NSString *const MBXExampleCustomStyle;

--- a/Examples/Examples.m
+++ b/Examples/Examples.m
@@ -14,6 +14,7 @@
     NSArray *initialList = [[NSMutableArray alloc] initWithArray:@[
         MBXExampleCalloutDelegateUsage,
         MBXExampleCameraAnimation,
+        MBXExampleCustomAnnotationModel,
         MBXExampleCustomCalloutView,
         MBXExampleCustomRasterStyle,
         MBXExampleCustomStyle,

--- a/Examples/ObjectiveC/CustomAnnotationModelExample.h
+++ b/Examples/ObjectiveC/CustomAnnotationModelExample.h
@@ -1,0 +1,13 @@
+//
+//  CustomAnnotationModelExample.h
+//  Examples
+//
+//  Created by Jason Wray on 5/20/16.
+//  Copyright © 2016 Mapbox. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface CustomAnnotationModelExample : UIViewController
+
+@end

--- a/Examples/ObjectiveC/CustomAnnotationModelExample.m
+++ b/Examples/ObjectiveC/CustomAnnotationModelExample.m
@@ -1,0 +1,114 @@
+//
+//  CustomAnnotationModelExample.m
+//  Examples
+//
+//  Created by Jason Wray on 5/20/16.
+//  Copyright © 2016 Mapbox. All rights reserved.
+//
+
+#import "CustomAnnotationModelExample.h"
+#import "CustomAnnotationModels.h"
+@import Mapbox;
+
+NSString *const MBXExampleCustomAnnotationModel = @"CustomAnnotationModelExample";
+
+@interface CustomAnnotationModelExample () <MGLMapViewDelegate>
+
+@end
+
+@implementation CustomAnnotationModelExample
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
+    mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    mapView.styleURL = [MGLStyle lightStyleURLWithVersion:9];
+    mapView.tintColor = [UIColor darkGrayColor];
+    mapView.zoomLevel = 1;
+    mapView.delegate = self;
+    [self.view addSubview:mapView];
+
+    // Point Annotation
+    CustomPointAnnotation *point = [[CustomPointAnnotation alloc] init];
+    point.coordinate = CLLocationCoordinate2DMake(0, 0);
+    point.title = @"Custom Point Annotation";
+    // Set the custom `image` and `reuseIdentifier` properties, later used in the `mapView:imageForAnnotation:` delegate method.
+    point.image = [self dotWithSize:20];
+    point.reuseIdentifier = @"yeOldeGreyDot";
+
+    // Polyline
+    // Create a coordinates array with all of the coordinates for our polyline.
+    CLLocationCoordinate2D coordinates[] = {
+        CLLocationCoordinate2DMake(35, -25),
+        CLLocationCoordinate2DMake(20, -30),
+        CLLocationCoordinate2DMake( 0, -25),
+        CLLocationCoordinate2DMake(-15,  0),
+        CLLocationCoordinate2DMake(-45, 10),
+        CLLocationCoordinate2DMake(-45, 40),
+    };
+    NSUInteger numberOfCoordinates = sizeof(coordinates) / sizeof(CLLocationCoordinate2D);
+
+    CustomPolyline *polyline = [CustomPolyline polylineWithCoordinates:coordinates count:numberOfCoordinates];//
+    // Set the custom `color` property, later used in the `mapView:strokeColorForShapeAnnotation:` delegate method.
+    polyline.color = [UIColor darkGrayColor];
+
+    // Add both annotations to the map.
+    [mapView addAnnotations:@[point, polyline]];
+}
+
+- (UIImage *)dotWithSize:(CGFloat)size {
+    CGRect rect = CGRectMake(0, 0, size, size);
+    CGFloat strokeWidth = 1;
+
+    UIGraphicsBeginImageContextWithOptions(rect.size, NO, [[UIScreen mainScreen] scale]);
+
+    UIBezierPath *ovalPath = [UIBezierPath bezierPathWithOvalInRect:CGRectInset(rect, strokeWidth, strokeWidth)];
+    [UIColor.darkGrayColor setFill];
+    [ovalPath fill];
+
+    [UIColor.whiteColor setStroke];
+    ovalPath.lineWidth = strokeWidth;
+    [ovalPath stroke];
+
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+
+    return image;
+}
+
+#pragma mark - MGLMapViewDelegate methods
+
+-(MGLAnnotationImage *)mapView:(MGLMapView *)mapView imageForAnnotation:(id<MGLAnnotation>)annotation {
+    if ([annotation isKindOfClass:[CustomPointAnnotation class]]) {
+        CustomPointAnnotation *point = (CustomPointAnnotation *)annotation;
+        MGLAnnotationImage *annotationImage = [mapView dequeueReusableAnnotationImageWithIdentifier:point.reuseIdentifier];
+
+        if (annotationImage) {
+            // The annotatation image has already been cached, just reuse it.
+            return annotationImage;
+        } else if (point.image && point.reuseIdentifier) {
+            // Create a new annotation image.
+            return [MGLAnnotationImage annotationImageWithImage:point.image reuseIdentifier:point.reuseIdentifier];
+        }
+    }
+
+    // Fallback to the default marker image.
+    return nil;
+}
+
+- (UIColor *)mapView:(MGLMapView *)mapView strokeColorForShapeAnnotation:(MGLShape *)annotation {
+    if ([annotation isKindOfClass:[CustomPolyline class]]) {
+        // Return orange if the polyline does not have a custom color.
+        return [(CustomPolyline *)annotation color] ?: [UIColor orangeColor];
+    }
+
+    // Fallback to the default tint color.
+    return mapView.tintColor;
+}
+
+-(BOOL)mapView:(MGLMapView *)mapView annotationCanShowCallout:(id<MGLAnnotation>)annotation {
+    return YES;
+}
+
+@end

--- a/Examples/ObjectiveC/CustomAnnotationModels.h
+++ b/Examples/ObjectiveC/CustomAnnotationModels.h
@@ -1,0 +1,40 @@
+//
+//  CustomAnnotationModels.h
+//  Examples
+//
+//  Created by Jason Wray on 5/20/16.
+//  Copyright © 2016 Mapbox. All rights reserved.
+//
+
+@import Mapbox;
+
+// MGLAnnotation protocol reimplementation
+@interface CustomPointAnnotation : NSObject <MGLAnnotation>
+
+// As a reimplementation of the MGLAnnotation protocol, we have to add mutable coordinate and (sub)title properties ourselves.
+@property (nonatomic, assign) CLLocationCoordinate2D coordinate;
+@property (nonatomic, copy, nullable) NSString *title;
+@property (nonatomic, copy, nullable) NSString *subtitle;
+
+// Custom properties that we will use to customize the annotation's image.
+@property (nonatomic, copy, nonnull) UIImage *image;
+@property (nonatomic, copy, nonnull) NSString *reuseIdentifier;
+
+@end
+
+@implementation CustomPointAnnotation
+@end
+
+
+// MGLPolyline subclass
+@interface CustomPolyline : MGLPolyline
+
+// Because this is a subclass of MGLPolyline, there is no need to redeclare its properties.
+
+// Custom property that we will use when drawing the polyline.
+@property (nonatomic, strong, nullable) UIColor *color;
+
+@end
+
+@implementation CustomPolyline
+@end

--- a/Examples/Swift/CustomAnnotationModelExample.swift
+++ b/Examples/Swift/CustomAnnotationModelExample.swift
@@ -1,0 +1,105 @@
+//
+//  CustomAnnotationModelExample.swift
+//  Examples
+//
+//  Created by Jason Wray on 5/20/16.
+//  Copyright © 2016 Mapbox. All rights reserved.
+//
+
+import Mapbox
+
+@objc(CustomAnnotationModelExample_Swift)
+
+class CustomAnnotationModelExample_Swift: UIViewController, MGLMapViewDelegate {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let mapView = MGLMapView(frame: view.bounds)
+        mapView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+        mapView.styleURL = MGLStyle.lightStyleURLWithVersion(9)
+        mapView.tintColor = .darkGrayColor()
+        mapView.zoomLevel = 1
+        mapView.delegate = self
+        view.addSubview(mapView)
+
+        // Point Annotation
+        let point = CustomPointAnnotation(coordinate: CLLocationCoordinate2DMake(0, 0),
+                                          title: "Custom Point Annotation",
+                                          subtitle: nil)
+        // Set the custom `image` and `reuseIdentifier` properties, later used in the `mapView:imageForAnnotation:` delegate method.
+        point.reuseIdentifier = "yeOldeGreyDot"
+        point.image = dotWithSize(20)
+
+        // Polyline
+        // Create a coordinates array with all of the coordinates for our polyline.
+        var coordinates = [
+            CLLocationCoordinate2DMake(35, -25),
+            CLLocationCoordinate2DMake(20, -30),
+            CLLocationCoordinate2DMake( 0, -25),
+            CLLocationCoordinate2DMake(-15,  0),
+            CLLocationCoordinate2DMake(-45, 10),
+            CLLocationCoordinate2DMake(-45, 40),
+        ]
+
+        let polyline = CustomPolyline(coordinates: &coordinates, count: UInt(coordinates.count))
+        // Set the custom `color` property, later used in the `mapView:strokeColorForShapeAnnotation:` delegate method.
+        polyline.color = .darkGrayColor()
+
+        // Add both annotations to the map.
+        mapView.addAnnotations([point, polyline])
+    }
+
+    func dotWithSize(size: CGFloat) -> (UIImage) {
+        let rect = CGRectMake(0, 0, size, size)
+        let strokeWidth: CGFloat = 1
+
+        UIGraphicsBeginImageContextWithOptions(rect.size, false, UIScreen.mainScreen().scale)
+
+        let ovalPath = UIBezierPath(ovalInRect: CGRectInset(rect, strokeWidth, strokeWidth))
+        UIColor.darkGrayColor().setFill()
+        ovalPath.fill()
+
+        UIColor.whiteColor().setStroke()
+        ovalPath.lineWidth = strokeWidth
+        ovalPath.stroke()
+
+        let image: UIImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        
+        return image
+    }
+
+    // MARK: - MGLMapViewDelegate methods
+
+    func mapView(mapView: MGLMapView, imageForAnnotation annotation: MGLAnnotation) -> MGLAnnotationImage? {
+        if let point = annotation as? CustomPointAnnotation,
+            image = point.image,
+            reuseIdentifier = point.reuseIdentifier {
+
+            if let annotationImage = mapView.dequeueReusableAnnotationImageWithIdentifier(reuseIdentifier) {
+                // The annotatation image has already been cached, just reuse it.
+                return annotationImage
+            } else {
+                // Create a new annotation image.
+                return MGLAnnotationImage(image: image, reuseIdentifier: reuseIdentifier)
+            }
+        }
+
+        // Fallback to the default marker image.
+        return nil
+    }
+
+    func mapView(mapView: MGLMapView, strokeColorForShapeAnnotation annotation: MGLShape) -> UIColor {
+        if let annotation = annotation as? CustomPolyline {
+            // Return orange if the polyline does not have a custom color.
+            return annotation.color ?? .orangeColor()
+        }
+
+        // Fallback to the default tint color.
+        return mapView.tintColor
+    }
+
+    func mapView(mapView: MGLMapView, annotationCanShowCallout annotation: MGLAnnotation) -> Bool {
+        return true
+    }
+}

--- a/Examples/Swift/CustomAnnotationModels.swift
+++ b/Examples/Swift/CustomAnnotationModels.swift
@@ -1,0 +1,36 @@
+//
+//  CustomAnnotationModels.swift
+//  Examples
+//
+//  Created by Jason Wray on 5/20/16.
+//  Copyright © 2016 Mapbox. All rights reserved.
+//
+
+import Mapbox
+
+// MGLAnnotation protocol reimplementation
+class CustomPointAnnotation : NSObject, MGLAnnotation {
+
+    // As a reimplementation of the MGLAnnotation protocol, we have to add mutable coordinate and (sub)title properties ourselves.
+    var coordinate: CLLocationCoordinate2D
+    var title: String?
+    var subtitle: String?
+
+    // Custom properties that we will use to customize the annotation's image.
+    var image: UIImage?
+    var reuseIdentifier: String?
+
+    init(coordinate: CLLocationCoordinate2D, title: String?, subtitle: String?) {
+        self.coordinate = coordinate
+        self.title = title
+        self.subtitle = subtitle
+    }
+}
+
+// MGLPolyline subclass
+class CustomPolyline : MGLPolyline {
+    // Because this is a subclass of MGLPolyline, there is no need to redeclare its properties.
+
+    // Custom property that we will use when drawing the polyline.
+    var color: UIColor?
+}


### PR DESCRIPTION
Shows an implementation of both the MGLAnnotation protocol (as a replacement for MGLPointAnnotation) and of MGLPolyline subclassing.
- Creates the point annotation image dynamically.
- Requires multiple files — one for the model, another for the view controller.
- The Swift version of CustomPointAnnotation has an initializer, because Swift (and it’s nice).

![simulator screen shot may 23 2016 1 46 25 pm](https://cloud.githubusercontent.com/assets/1198851/15479165/d8214b8e-20ec-11e6-88e4-3972ee8d38ff.png)

Fixes #19.

/cc @1ec5
