### PR TITLE
Add custom user location annotation example

### DIFF
--- a/Examples.xcodeproj/project.pbxproj
+++ b/Examples.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		962B45111D1C8541007B7454 /* AnnotationViewExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 962B45101D1C8541007B7454 /* AnnotationViewExample.swift */; };
 		96466ACA1C9323D9009CF4AB /* CustomCalloutViewExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96466AC91C9323D9009CF4AB /* CustomCalloutViewExample.swift */; };
 		96466AD11C932EF5009CF4AB /* CustomCalloutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96466AD01C932EF5009CF4AB /* CustomCalloutView.swift */; };
+		9668F1871D668DCC009D555A /* UserLocationAnnotationExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9668F1861D668DCC009D555A /* UserLocationAnnotationExample.swift */; };
+		9668F18A1D668DE2009D555A /* UserLocationAnnotationExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 9668F1891D668DE2009D555A /* UserLocationAnnotationExample.m */; };
 		9678E3EE1CEF58DA00F21AE2 /* CustomAnnotationModelExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 9678E3ED1CEF58DA00F21AE2 /* CustomAnnotationModelExample.m */; };
 		9678E3F01CEF591000F21AE2 /* CustomAnnotationModelExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9678E3EF1CEF591000F21AE2 /* CustomAnnotationModelExample.swift */; };
 		9678E3F41CEFA9B500F21AE2 /* CustomAnnotationModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9678E3F31CEFA9B500F21AE2 /* CustomAnnotationModels.swift */; };
@@ -124,6 +126,9 @@
 		962B45101D1C8541007B7454 /* AnnotationViewExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AnnotationViewExample.swift; path = Examples/Swift/AnnotationViewExample.swift; sourceTree = SOURCE_ROOT; };
 		96466AC91C9323D9009CF4AB /* CustomCalloutViewExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CustomCalloutViewExample.swift; path = Examples/Swift/CustomCalloutViewExample.swift; sourceTree = SOURCE_ROOT; };
 		96466AD01C932EF5009CF4AB /* CustomCalloutView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CustomCalloutView.swift; path = Examples/Swift/CustomCalloutView.swift; sourceTree = SOURCE_ROOT; };
+		9668F1861D668DCC009D555A /* UserLocationAnnotationExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserLocationAnnotationExample.swift; path = Examples/Swift/UserLocationAnnotationExample.swift; sourceTree = SOURCE_ROOT; };
+		9668F1881D668DE2009D555A /* UserLocationAnnotationExample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserLocationAnnotationExample.h; sourceTree = "<group>"; };
+		9668F1891D668DE2009D555A /* UserLocationAnnotationExample.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UserLocationAnnotationExample.m; sourceTree = "<group>"; };
 		9678E3EC1CEF58DA00F21AE2 /* CustomAnnotationModelExample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CustomAnnotationModelExample.h; sourceTree = "<group>"; };
 		9678E3ED1CEF58DA00F21AE2 /* CustomAnnotationModelExample.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CustomAnnotationModelExample.m; sourceTree = "<group>"; };
 		9678E3EF1CEF591000F21AE2 /* CustomAnnotationModelExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CustomAnnotationModelExample.swift; path = Examples/Swift/CustomAnnotationModelExample.swift; sourceTree = SOURCE_ROOT; };
@@ -305,6 +310,7 @@
 				968247281C5C1FF800494AB8 /* PointConversionExample.h */,
 				968247061C5BEBDC00494AB8 /* SatelliteStyleExample.h */,
 				9691AAA51C5AAD8F006A58C6 /* SimpleMapViewExample.h */,
+				9668F1881D668DE2009D555A /* UserLocationAnnotationExample.h */,
 				969E7FDB1D25C31700663F84 /* UserTrackingModesExample.h */,
 			);
 			name = Headers;
@@ -353,6 +359,8 @@
 				968247091C5BEE4D00494AB8 /* SatelliteStyleExample.swift */,
 				9691AAA61C5AAD8F006A58C6 /* SimpleMapViewExample.m */,
 				9691AAAD1C5AB5A1006A58C6 /* SimpleMapViewExample.swift */,
+				9668F1891D668DE2009D555A /* UserLocationAnnotationExample.m */,
+				9668F1861D668DCC009D555A /* UserLocationAnnotationExample.swift */,
 				969E7FDC1D25C31700663F84 /* UserTrackingModesExample.m */,
 				969E7FDE1D25C38800663F84 /* UserTrackingModesExample.swift */,
 			);
@@ -504,6 +512,7 @@
 				969E7FDF1D25C38800663F84 /* UserTrackingModesExample.swift in Sources */,
 				96A2A1CF1C8CA16C0059441E /* CustomCalloutViewExample.m in Sources */,
 				9682470F1C5BF12700494AB8 /* DrawingAMarkerExample.m in Sources */,
+				9668F1871D668DCC009D555A /* UserLocationAnnotationExample.swift in Sources */,
 				961962941C581700002D3DAB /* AppDelegate.m in Sources */,
 				968247171C5C10B100494AB8 /* DrawingAGeoJSONLineExample.swift in Sources */,
 				9691AAA71C5AAD8F006A58C6 /* CustomStyleExample.m in Sources */,
@@ -538,6 +547,7 @@
 				96466AD11C932EF5009CF4AB /* CustomCalloutView.swift in Sources */,
 				961962D51C583FDC002D3DAB /* ExamplesContainerViewController.m in Sources */,
 				9691AAB11C5AC5AD006A58C6 /* CustomStyleExample.swift in Sources */,
+				9668F18A1D668DE2009D555A /* UserLocationAnnotationExample.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Examples/Examples.h
+++ b/Examples/Examples.h
@@ -31,6 +31,7 @@ extern NSString *const MBXExampleOfflinePack;
 extern NSString *const MBXExamplePointConversion;
 extern NSString *const MBXExampleSatelliteStyle;
 extern NSString *const MBXExampleSimpleMapView;
+extern NSString *const MBXExampleUserLocationAnnotation;
 extern NSString *const MBXExampleUserTrackingModes;
 
 @interface Examples : NSObject

--- a/Examples/Examples.m
+++ b/Examples/Examples.m
@@ -29,6 +29,7 @@
         MBXExamplePointConversion,
         MBXExampleSatelliteStyle,
         MBXExampleSimpleMapView,
+        MBXExampleUserLocationAnnotation,
         MBXExampleUserTrackingModes,
     ]];
 

--- a/Examples/ObjectiveC/UserLocationAnnotationExample.h
+++ b/Examples/ObjectiveC/UserLocationAnnotationExample.h
@@ -1,0 +1,13 @@
+//
+//  UserLocationAnnotationExample.h
+//  Examples
+//
+//  Created by Jason Wray on 8/18/16.
+//  Copyright © 2016 Mapbox. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UserLocationAnnotationExample : UIViewController
+
+@end

--- a/Examples/ObjectiveC/UserLocationAnnotationExample.m
+++ b/Examples/ObjectiveC/UserLocationAnnotationExample.m
@@ -12,6 +12,118 @@
 
 NSString *const MBXExampleUserLocationAnnotation = @"UserLocationAnnotationExample";
 
+
+// MGLUserLocationAnnotationView subclass
+@interface CustomUserLocationAnnotationView : MGLUserLocationAnnotationView
+
+@property (nonatomic) CGFloat size;
+@property (nonatomic) CGFloat arrowSize;
+
+@property (nonatomic) CALayer *dot;
+@property (nonatomic) CAShapeLayer *arrow;
+
+@end
+
+@implementation CustomUserLocationAnnotationView
+
+- (instancetype)init {
+    self.size = 25;
+    self = [super initWithFrame:CGRectMake(0, 0, self.size, self.size)];
+
+    return self;
+}
+
+- (void)update {
+    // This method can be called many times a second, so be careful to keep it lightweight.
+    if (CLLocationCoordinate2DIsValid(self.userLocation.coordinate)) {
+        [self setupLayers];
+        [self updateHeading];
+    }
+}
+
+- (void)updateHeading {
+    // Show the heading arrow, if we’re able to.
+    if (self.userLocation.heading && self.mapView.userTrackingMode == MGLUserTrackingModeFollowWithHeading) {
+        _arrow.hidden = NO;
+
+        // Rotate the arrow according to the user’s heading.
+        CGAffineTransform rotation = CGAffineTransformRotate(
+            CGAffineTransformIdentity,
+            -MGLRadiansFromDegrees(self.mapView.direction - self.userLocation.heading.trueHeading));
+        [self.layer setAffineTransform:rotation];
+    } else {
+        _arrow.hidden = YES;
+    }
+}
+
+- (void)setupLayers {
+    [self setupDot];
+    [self setupArrow];
+}
+
+- (void)setupDot {
+    if (!_dot) {
+        _dot = [CALayer layer];
+        _dot.bounds = CGRectMake(0, 0, _size, _size);
+        _dot.position = CGPointMake(_size / 2, _size / 2);
+
+        // Use CALayer’s corner radius to turn this layer into a circle.
+        _dot.cornerRadius = _size / 2;
+        _dot.backgroundColor = super.tintColor.CGColor;
+        _dot.borderWidth = 2;
+        _dot.borderColor = [UIColor whiteColor].CGColor;
+        _dot.shadowColor = [UIColor blackColor].CGColor;
+        _dot.shadowOffset = CGSizeMake(0, 0);
+
+        [self.layer addSublayer:_dot];
+    }
+}
+
+- (void)setupArrow {
+    if (!_arrow) {
+        _arrowSize = _size / 2.5;
+
+        _arrow = [CAShapeLayer layer];
+        _arrow.path = [self arrowPath];
+
+        _arrow.bounds = CGRectMake(0, 0, _arrowSize, _arrowSize);
+        _arrow.position = CGPointMake(_size / 2, -5);
+
+        _arrow.fillColor = super.tintColor.CGColor;
+
+//        _arrow.borderColor = [UIColor colorWithWhite:0 alpha:0.25].CGColor;
+//        _arrow.borderWidth = 1;
+
+        [self.layer addSublayer:_arrow];
+    }
+}
+
+- (CGPathRef)arrowPath {
+    CGFloat max = _arrowSize;
+
+    CGPoint top = CGPointMake(max * 0.5, max * 0.4);
+    CGPoint left = CGPointMake(0, max);
+    CGPoint right = CGPointMake(max, max);
+    CGPoint center = CGPointMake(max * 0.5, max * 0.8);
+
+    UIBezierPath *bezierPath = [UIBezierPath bezierPath];
+    [bezierPath moveToPoint:top];
+    [bezierPath addLineToPoint:left];
+    [bezierPath addQuadCurveToPoint:right controlPoint:center];
+    [bezierPath addLineToPoint:top];
+    [bezierPath closePath];
+
+    return bezierPath.CGPath;
+}
+
+@end
+
+
+//
+// Example view controller
+@interface UserLocationAnnotationExample () <MGLMapViewDelegate>
+@end
+
 @implementation UserLocationAnnotationExample
 
 - (void)viewDidLoad {
@@ -19,7 +131,23 @@ NSString *const MBXExampleUserLocationAnnotation = @"UserLocationAnnotationExamp
 
     MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
     mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    mapView.delegate = self;
+
+    // Enable heading tracking mode so that the arrow will appear.
+    mapView.userTrackingMode = MGLUserTrackingModeFollowWithHeading;
+
     [self.view addSubview:mapView];
+}
+
+// MARK: - MGLMapViewDelegate methods
+
+- (MGLAnnotationView *)mapView:(MGLMapView *)mapView viewForAnnotation:(id<MGLAnnotation>)annotation {
+    // This is how we substitute a custom view for the user location annotation.
+    if ([annotation isKindOfClass:[MGLUserLocation class]]) {
+        return [[CustomUserLocationAnnotationView alloc] init];
+    }
+
+    return nil;
 }
 
 @end

--- a/Examples/ObjectiveC/UserLocationAnnotationExample.m
+++ b/Examples/ObjectiveC/UserLocationAnnotationExample.m
@@ -1,0 +1,25 @@
+//
+//  UserLocationAnnotationExample.m
+//  Examples
+//
+//  Created by Jason Wray on 8/18/16.
+//  Copyright © 2016 Mapbox. All rights reserved.
+//
+
+#import "UserLocationAnnotationExample.h"
+
+@import Mapbox;
+
+NSString *const MBXExampleUserLocationAnnotation = @"UserLocationAnnotationExample";
+
+@implementation UserLocationAnnotationExample
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
+    mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [self.view addSubview:mapView];
+}
+
+@end

--- a/Examples/Swift/UserLocationAnnotationExample.swift
+++ b/Examples/Swift/UserLocationAnnotationExample.swift
@@ -49,6 +49,8 @@ class CustomUserLocationAnnotationView: MGLUserLocationAnnotationView {
     override func update() {
         if CGRectIsNull(frame) {
             frame = CGRectMake(0, 0, size, size)
+
+            return setNeedsLayout()
         }
 
         // This method can be called many times a second, so be careful to keep it lightweight.
@@ -83,7 +85,7 @@ class CustomUserLocationAnnotationView: MGLUserLocationAnnotationView {
         if dot == nil {
             dot = CALayer()
             dot.bounds = CGRectMake(0, 0, size, size)
-            dot.position = CGPointMake(super.bounds.size.width / 2, super.bounds.size.height / 2)
+            dot.position = CGPointMake(size / 2, size / 2)
 
             // Use CALayer’s corner radius to turn this layer into a circle.
             dot.cornerRadius = size / 2
@@ -104,11 +106,13 @@ class CustomUserLocationAnnotationView: MGLUserLocationAnnotationView {
             arrow = CAShapeLayer()
             arrow.path = arrowPath()
 
-            // We use a long, skinny bounds so that the center remains the same as the dot. This makes rotation easier.
-            arrow.bounds = CGRectMake(0, 0, arrowSize, size + (arrowSize * 2))
-            arrow.position = CGPointMake(super.bounds.size.width / 2, 0)
+            arrow.bounds = CGRectMake(0, 0, arrowSize, arrowSize)
+            arrow.position = CGPointMake(size / 2, -5)
 
             arrow.fillColor = super.tintColor.CGColor
+
+            arrow.borderColor = UIColor(white: 0, alpha: 0.25).CGColor
+            arrow.borderWidth = 1
 
             layer.addSublayer(arrow)
         }

--- a/Examples/Swift/UserLocationAnnotationExample.swift
+++ b/Examples/Swift/UserLocationAnnotationExample.swift
@@ -35,7 +35,7 @@ class UserLocationAnnotationExample_Swift: UIViewController, MGLMapViewDelegate 
 }
 
 class CustomUserLocationAnnotationView: MGLUserLocationAnnotationView {
-    let size: CGFloat = 40
+    let size: CGFloat = 25
 
     var dot: CALayer!
     var arrow: CAShapeLayer!
@@ -93,27 +93,32 @@ class CustomUserLocationAnnotationView: MGLUserLocationAnnotationView {
         if arrow == nil {
             arrow = CAShapeLayer()
             arrow.path = arrowPath()
-            arrow.bounds = CGRectMake(0, 0, size / 2, size / 2)
-            arrow.position = CGPointMake(super.bounds.size.width / 2, super.bounds.size.height / 2)
+            arrow.bounds = CGRectMake(0, 0, size / 3, size * 1.66)
+            arrow.position = CGPointMake(super.bounds.size.width / 2, 0)
             arrow.shouldRasterize = true
             arrow.rasterizationScale = UIScreen.mainScreen().scale
             arrow.drawsAsynchronously = true
 
-            arrow.fillColor = UIColor.whiteColor().CGColor
+            //arrow.borderWidth = 1
+            //arrow.borderColor = UIColor(white: 0, alpha: 0.25).CGColor
+
+            arrow.fillColor = super.tintColor.CGColor ?? UIColor.whiteColor().CGColor
 
             layer.addSublayer(arrow)
         }
     }
 
     private func arrowPath() -> CGPath {
-        let max: CGFloat = size / 2
+        let max: CGFloat = size / 3
+        let tip: CGPoint = CGPointMake(max * 0.5, max * 0.4)
 
         let bezierPath = UIBezierPath()
-        bezierPath.moveToPoint(CGPointMake(max * 0.5, 0))
-        bezierPath.addLineToPoint(CGPointMake(max * 0.1, max))
-        bezierPath.addLineToPoint(CGPointMake(max * 0.5, max * 0.65))
-        bezierPath.addLineToPoint(CGPointMake(max * 0.9, max))
-        bezierPath.addLineToPoint(CGPointMake(max * 0.5, 0))
+        bezierPath.moveToPoint(tip)
+        bezierPath.addLineToPoint(CGPointMake(0, max)) // left tip
+        bezierPath.addLineToPoint(CGPointMake(max * 0.5, max * 0.9)) // center divot
+        bezierPath.addLineToPoint(CGPointMake(max, max)) // right tip
+        bezierPath.addLineToPoint(tip)
+
         bezierPath.closePath()
 
         return bezierPath.CGPath

--- a/Examples/Swift/UserLocationAnnotationExample.swift
+++ b/Examples/Swift/UserLocationAnnotationExample.swift
@@ -36,6 +36,7 @@ class UserLocationAnnotationExample_Swift: UIViewController, MGLMapViewDelegate 
 
 class CustomUserLocationAnnotationView: MGLUserLocationAnnotationView {
     let size: CGFloat = 25
+    var arrowSize: CGFloat!
 
     var dot: CALayer!
     var arrow: CAShapeLayer!
@@ -91,9 +92,11 @@ class CustomUserLocationAnnotationView: MGLUserLocationAnnotationView {
 
     private func setupArrow() {
         if arrow == nil {
+            arrowSize = size / 2.5
+
             arrow = CAShapeLayer()
             arrow.path = arrowPath()
-            arrow.bounds = CGRectMake(0, 0, size / 3, size * 1.66)
+            arrow.bounds = CGRectMake(0, 0, arrowSize, size + (arrowSize * 2))
             arrow.position = CGPointMake(super.bounds.size.width / 2, 0)
             arrow.shouldRasterize = true
             arrow.rasterizationScale = UIScreen.mainScreen().scale
@@ -109,12 +112,12 @@ class CustomUserLocationAnnotationView: MGLUserLocationAnnotationView {
     }
 
     private func arrowPath() -> CGPath {
-        let max: CGFloat = size / 3
+        let max: CGFloat = arrowSize
 
         let top = CGPointMake(max * 0.5, max * 0.4)
         let left = CGPointMake(0, max)
         let right = CGPointMake(max, max)
-        let center = CGPointMake(max * 0.5, max * 0.75)
+        let center = CGPointMake(max * 0.5, max * 0.8)
 
         let bezierPath = UIBezierPath()
         bezierPath.moveToPoint(top)

--- a/Examples/Swift/UserLocationAnnotationExample.swift
+++ b/Examples/Swift/UserLocationAnnotationExample.swift
@@ -1,0 +1,122 @@
+//
+//  UserLocationAnnotationExample.swift
+//  Examples
+//
+//  Created by Jason Wray on 8/18/16.
+//  Copyright © 2016 Mapbox. All rights reserved.
+//
+
+import Foundation
+
+import Mapbox
+
+@objc(UserLocationAnnotationExample_Swift)
+
+class UserLocationAnnotationExample_Swift: UIViewController, MGLMapViewDelegate {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let mapView = MGLMapView(frame: view.bounds)
+        mapView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+        mapView.delegate = self
+
+        mapView.userTrackingMode = .FollowWithHeading
+
+        view.addSubview(mapView)
+    }
+
+    func mapView(mapView: MGLMapView, viewForAnnotation annotation: MGLAnnotation) -> MGLAnnotationView? {
+        if annotation is MGLUserLocation && mapView.userLocation != nil {
+            return CustomUserLocationAnnotationView()
+        }
+
+        return nil
+    }
+}
+
+class CustomUserLocationAnnotationView: MGLUserLocationAnnotationView {
+    let size: CGFloat = 40
+
+    var dot: CALayer!
+    var arrow: CAShapeLayer!
+
+    override func update() {
+        if CGRectIsNull(frame) {
+            frame = CGRectMake(0, 0, size, size)
+        }
+
+        if CLLocationCoordinate2DIsValid(self.userLocation!.coordinate) {
+            setupLayers()
+            updateHeading()
+        }
+    }
+
+    private func updateHeading() {
+        if let heading = userLocation!.heading where mapView?.userTrackingMode == .FollowWithHeading {
+            arrow.hidden = false
+
+            let rotation = CGAffineTransformRotate(
+                CGAffineTransformIdentity,
+                -MGLRadiansFromDegrees(mapView!.direction - heading.trueHeading))
+            layer.setAffineTransform(rotation)
+        } else {
+            arrow.hidden = true
+        }
+    }
+
+    private func setupLayers() {
+        setupDot()
+        setupArrow()
+    }
+
+    private func setupDot() {
+        if dot == nil {
+            dot = CALayer()
+            dot.bounds = CGRectMake(0, 0, size, size)
+            dot.position = CGPointMake(super.bounds.size.width / 2, super.bounds.size.height / 2)
+            dot.shouldRasterize = true
+            dot.rasterizationScale = UIScreen.mainScreen().scale
+            dot.drawsAsynchronously = true
+
+            dot.cornerRadius = size / 2
+            dot.backgroundColor = super.tintColor.CGColor ?? UIColor.redColor().CGColor
+            dot.borderWidth = 2
+            dot.borderColor = UIColor.whiteColor().CGColor
+            dot.shadowColor = UIColor.blackColor().CGColor
+            dot.shadowOffset = CGSizeMake(0, 0)
+
+            layer.addSublayer(dot)
+        }
+    }
+
+    private func setupArrow() {
+        if arrow == nil {
+            arrow = CAShapeLayer()
+            arrow.path = arrowPath()
+            arrow.bounds = CGRectMake(0, 0, size / 2, size / 2)
+            arrow.position = CGPointMake(super.bounds.size.width / 2, super.bounds.size.height / 2)
+            arrow.shouldRasterize = true
+            arrow.rasterizationScale = UIScreen.mainScreen().scale
+            arrow.drawsAsynchronously = true
+
+            arrow.fillColor = UIColor.whiteColor().CGColor
+
+            layer.addSublayer(arrow)
+        }
+    }
+
+    private func arrowPath() -> CGPath {
+        let max: CGFloat = size / 2
+
+        let bezierPath = UIBezierPath()
+        bezierPath.moveToPoint(CGPointMake(max * 0.5, 0))
+        bezierPath.addLineToPoint(CGPointMake(max * 0.1, max))
+        bezierPath.addLineToPoint(CGPointMake(max * 0.5, max * 0.65))
+        bezierPath.addLineToPoint(CGPointMake(max * 0.9, max))
+        bezierPath.addLineToPoint(CGPointMake(max * 0.5, 0))
+        bezierPath.closePath()
+
+        return bezierPath.CGPath
+    }
+}
+

--- a/Examples/Swift/UserLocationAnnotationExample.swift
+++ b/Examples/Swift/UserLocationAnnotationExample.swift
@@ -110,15 +110,17 @@ class CustomUserLocationAnnotationView: MGLUserLocationAnnotationView {
 
     private func arrowPath() -> CGPath {
         let max: CGFloat = size / 3
-        let tip: CGPoint = CGPointMake(max * 0.5, max * 0.4)
+
+        let top = CGPointMake(max * 0.5, max * 0.4)
+        let left = CGPointMake(0, max)
+        let right = CGPointMake(max, max)
+        let center = CGPointMake(max * 0.5, max * 0.75)
 
         let bezierPath = UIBezierPath()
-        bezierPath.moveToPoint(tip)
-        bezierPath.addLineToPoint(CGPointMake(0, max)) // left tip
-        bezierPath.addLineToPoint(CGPointMake(max * 0.5, max * 0.9)) // center divot
-        bezierPath.addLineToPoint(CGPointMake(max, max)) // right tip
-        bezierPath.addLineToPoint(tip)
-
+        bezierPath.moveToPoint(top)
+        bezierPath.addLineToPoint(left)
+        bezierPath.addQuadCurveToPoint(right, controlPoint: center)
+        bezierPath.addLineToPoint(top)
         bezierPath.closePath()
 
         return bezierPath.CGPath

--- a/Examples/Swift/UserLocationAnnotationExample.swift
+++ b/Examples/Swift/UserLocationAnnotationExample.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2016 Mapbox. All rights reserved.
 //
 
-import Foundation
-
 import Mapbox
 
 @objc(UserLocationAnnotationExample_Swift)
@@ -80,7 +78,7 @@ class CustomUserLocationAnnotationView: MGLUserLocationAnnotationView {
             dot.drawsAsynchronously = true
 
             dot.cornerRadius = size / 2
-            dot.backgroundColor = super.tintColor.CGColor ?? UIColor.redColor().CGColor
+            dot.backgroundColor = super.tintColor.CGColor
             dot.borderWidth = 2
             dot.borderColor = UIColor.whiteColor().CGColor
             dot.shadowColor = UIColor.blackColor().CGColor
@@ -102,10 +100,7 @@ class CustomUserLocationAnnotationView: MGLUserLocationAnnotationView {
             arrow.rasterizationScale = UIScreen.mainScreen().scale
             arrow.drawsAsynchronously = true
 
-            //arrow.borderWidth = 1
-            //arrow.borderColor = UIColor(white: 0, alpha: 0.25).CGColor
-
-            arrow.fillColor = super.tintColor.CGColor ?? UIColor.whiteColor().CGColor
+            arrow.fillColor = super.tintColor.CGColor
 
             layer.addSublayer(arrow)
         }

--- a/Examples/Swift/UserLocationAnnotationExample.swift
+++ b/Examples/Swift/UserLocationAnnotationExample.swift
@@ -10,6 +10,7 @@ import Mapbox
 
 @objc(UserLocationAnnotationExample_Swift)
 
+// Example view controller
 class UserLocationAnnotationExample_Swift: UIViewController, MGLMapViewDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -18,12 +19,16 @@ class UserLocationAnnotationExample_Swift: UIViewController, MGLMapViewDelegate 
         mapView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
         mapView.delegate = self
 
+        // Enable heading tracking mode so that the arrow will appear.
         mapView.userTrackingMode = .FollowWithHeading
 
         view.addSubview(mapView)
     }
 
+    // MARK: - MGLMapViewDelegate methods
+
     func mapView(mapView: MGLMapView, viewForAnnotation annotation: MGLAnnotation) -> MGLAnnotationView? {
+        // This is how we substitute a custom view for the user location annotation.
         if annotation is MGLUserLocation && mapView.userLocation != nil {
             return CustomUserLocationAnnotationView()
         }
@@ -32,6 +37,8 @@ class UserLocationAnnotationExample_Swift: UIViewController, MGLMapViewDelegate 
     }
 }
 
+//
+// MGLUserLocationAnnotationView subclass
 class CustomUserLocationAnnotationView: MGLUserLocationAnnotationView {
     let size: CGFloat = 25
     var arrowSize: CGFloat!
@@ -44,6 +51,8 @@ class CustomUserLocationAnnotationView: MGLUserLocationAnnotationView {
             frame = CGRectMake(0, 0, size, size)
         }
 
+        // This method can be called many times a second, so be careful to keep it lightweight.
+
         if CLLocationCoordinate2DIsValid(self.userLocation!.coordinate) {
             setupLayers()
             updateHeading()
@@ -51,9 +60,11 @@ class CustomUserLocationAnnotationView: MGLUserLocationAnnotationView {
     }
 
     private func updateHeading() {
+        // Show the heading arrow, if we’re able to.
         if let heading = userLocation!.heading where mapView?.userTrackingMode == .FollowWithHeading {
             arrow.hidden = false
 
+            // Rotate the arrow according to the user’s heading.
             let rotation = CGAffineTransformRotate(
                 CGAffineTransformIdentity,
                 -MGLRadiansFromDegrees(mapView!.direction - heading.trueHeading))
@@ -73,10 +84,8 @@ class CustomUserLocationAnnotationView: MGLUserLocationAnnotationView {
             dot = CALayer()
             dot.bounds = CGRectMake(0, 0, size, size)
             dot.position = CGPointMake(super.bounds.size.width / 2, super.bounds.size.height / 2)
-            dot.shouldRasterize = true
-            dot.rasterizationScale = UIScreen.mainScreen().scale
-            dot.drawsAsynchronously = true
 
+            // Use CALayer’s corner radius to turn this layer into a circle.
             dot.cornerRadius = size / 2
             dot.backgroundColor = super.tintColor.CGColor
             dot.borderWidth = 2
@@ -94,11 +103,10 @@ class CustomUserLocationAnnotationView: MGLUserLocationAnnotationView {
 
             arrow = CAShapeLayer()
             arrow.path = arrowPath()
+
+            // We use a long, skinny bounds so that the center remains the same as the dot. This makes rotation easier.
             arrow.bounds = CGRectMake(0, 0, arrowSize, size + (arrowSize * 2))
             arrow.position = CGPointMake(super.bounds.size.width / 2, 0)
-            arrow.shouldRasterize = true
-            arrow.rasterizationScale = UIScreen.mainScreen().scale
-            arrow.drawsAsynchronously = true
 
             arrow.fillColor = super.tintColor.CGColor
 


### PR DESCRIPTION
Adds a custom user location example.
- Does not attempt to handle accuracy or pitch.
- I would like to have a permanent heading indicator, but this depends on https://github.com/mapbox/mapbox-gl-native/issues/5523.
### Todo
- [x] Objective-C
- [ ] Cleanup and review.

![](https://cloud.githubusercontent.com/assets/1198851/17798528/e7fbe94a-659f-11e6-94f8-83b07291f81d.jpg)

/cc @1ec5 @frederoni 
