### PR TITLE
Add DDS circle layer example

### DIFF
--- a/Examples.xcodeproj/project.pbxproj
+++ b/Examples.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		079E77C51E1C4E2100F92FA8 /* camera.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 079E77C41E1C4E2100F92FA8 /* camera.xcassets */; };
+		07C138C41E721C8F00D6F678 /* DDSCircleLayerExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C138C31E721C8F00D6F678 /* DDSCircleLayerExample.swift */; };
+		07C138C71E72216E00D6F678 /* DDSCircleLayerExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 07C138C61E72216E00D6F678 /* DDSCircleLayerExample.m */; };
 		07F53B851E00D02100B58DB3 /* AnnotationViewMultipleExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 07F53B841E00D02100B58DB3 /* AnnotationViewMultipleExample.m */; };
 		3EBCD7161DC28240001E342F /* AnnotationViewExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBCD7021DC28240001E342F /* AnnotationViewExample.swift */; };
 		3EBCD7171DC28240001E342F /* CalloutDelegateUsageExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBCD7031DC28240001E342F /* CalloutDelegateUsageExample.swift */; };
@@ -168,6 +170,9 @@
 
 /* Begin PBXFileReference section */
 		079E77C41E1C4E2100F92FA8 /* camera.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = camera.xcassets; sourceTree = "<group>"; };
+		07C138C31E721C8F00D6F678 /* DDSCircleLayerExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDSCircleLayerExample.swift; sourceTree = "<group>"; };
+		07C138C51E72216D00D6F678 /* DDSCircleLayerExample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDSCircleLayerExample.h; sourceTree = "<group>"; };
+		07C138C61E72216E00D6F678 /* DDSCircleLayerExample.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDSCircleLayerExample.m; sourceTree = "<group>"; };
 		07F53B841E00D02100B58DB3 /* AnnotationViewMultipleExample.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AnnotationViewMultipleExample.m; sourceTree = "<group>"; };
 		07F53B861E00D08600B58DB3 /* AnnotationViewMultipleExample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AnnotationViewMultipleExample.h; sourceTree = "<group>"; };
 		3EBCD7021DC28240001E342F /* AnnotationViewExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnnotationViewExample.swift; sourceTree = "<group>"; };
@@ -334,6 +339,7 @@
 				96A2A1CE1C8CA16C0059441E /* CustomCalloutViewExample.m */,
 				968247021C5BDCBB00494AB8 /* CustomRasterStyleExample.m */,
 				9691AAA21C5AAD8F006A58C6 /* CustomStyleExample.m */,
+				07C138C61E72216E00D6F678 /* DDSCircleLayerExample.m */,
 				9691AAA41C5AAD8F006A58C6 /* DefaultStylesExample.m */,
 				960A21601D344F9F00BB348B /* DraggableAnnotationViewExample.m */,
 				96D431FB1C84B4F7007D09D1 /* DrawingACustomMarkerExample.m */,
@@ -371,6 +377,7 @@
 				3EBCD7081DC28240001E342F /* CustomCalloutViewExample.swift */,
 				3EBCD7091DC28240001E342F /* CustomRasterStyleExample.swift */,
 				3EBCD70A1DC28240001E342F /* CustomStyleExample.swift */,
+				07C138C31E721C8F00D6F678 /* DDSCircleLayerExample.swift */,
 				3EBCD70B1DC28240001E342F /* DefaultStylesExample.swift */,
 				3EBCD70C1DC28240001E342F /* DraggableAnnotationViewExample.swift */,
 				3EBCD70D1DC28240001E342F /* DrawingACustomMarkerExample.swift */,
@@ -491,6 +498,7 @@
 				96A2A1CD1C8CA16C0059441E /* CustomCalloutViewExample.h */,
 				968247011C5BDCBB00494AB8 /* CustomRasterStyleExample.h */,
 				9691AAA11C5AAD8F006A58C6 /* CustomStyleExample.h */,
+				07C138C51E72216D00D6F678 /* DDSCircleLayerExample.h */,
 				9691AAA31C5AAD8F006A58C6 /* DefaultStylesExample.h */,
 				960A215F1D344F9F00BB348B /* DraggableAnnotationViewExample.h */,
 				96D431FA1C84B4F7007D09D1 /* DrawingACustomMarkerExample.h */,
@@ -718,12 +726,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				07C138C71E72216E00D6F678 /* DDSCircleLayerExample.m in Sources */,
 				3EBCD7191DC28240001E342F /* CustomAnnotationModelExample.swift in Sources */,
 				962B450F1D1C8520007B7454 /* AnnotationViewExample.m in Sources */,
 				3ED403411E006B5200230C95 /* CameraFlyToExample.swift in Sources */,
 				9691AAA91C5AAD8F006A58C6 /* SimpleMapViewExample.m in Sources */,
 				960A21611D344F9F00BB348B /* DraggableAnnotationViewExample.m in Sources */,
 				646B62B41DEF9613000AA523 /* RuntimeCircleStylesExample.swift in Sources */,
+				07C138C41E721C8F00D6F678 /* DDSCircleLayerExample.swift in Sources */,
 				646B62BD1DEF965A000AA523 /* RuntimeCircleStylesExample.m in Sources */,
 				646B629C1DEF6DF1000AA523 /* RuntimeToggleLayerExample.m in Sources */,
 				96A2A1CF1C8CA16C0059441E /* CustomCalloutViewExample.m in Sources */,

--- a/Examples/Examples.h
+++ b/Examples/Examples.h
@@ -23,6 +23,7 @@ extern NSString *const MBXExampleCustomAnnotationModel;
 extern NSString *const MBXExampleCustomCalloutView;
 extern NSString *const MBXExampleCustomRasterStyle;
 extern NSString *const MBXExampleCustomStyle;
+extern NSString *const MBXExampleDDSCircleLayer;
 extern NSString *const MBXExampleDefaultStyles;
 extern NSString *const MBXExampleDraggableAnnotationView;
 extern NSString *const MBXExampleDrawingAGeoJSONLine;

--- a/Examples/Examples.m
+++ b/Examples/Examples.m
@@ -22,6 +22,7 @@
         MBXExampleCustomCalloutView,
         MBXExampleCustomRasterStyle,
         MBXExampleCustomStyle,
+        MBXExampleDDSCircleLayer,
         MBXExampleDefaultStyles,
         MBXExampleDraggableAnnotationView,
         MBXExampleDrawingAGeoJSONLine,

--- a/Examples/ObjectiveC/DDSCircleLayerExample.h
+++ b/Examples/ObjectiveC/DDSCircleLayerExample.h
@@ -1,0 +1,13 @@
+//
+//  DDSCircleLayerExample.h
+//  Examples
+//
+//  Created by Nadia Barbosa on 3/9/17.
+//  Copyright © 2017 Mapbox. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface DDSCircleLayerExample : UIViewController
+
+@end

--- a/Examples/ObjectiveC/DDSCircleLayerExample.m
+++ b/Examples/ObjectiveC/DDSCircleLayerExample.m
@@ -1,0 +1,65 @@
+#import "DDSCircleLayerExample.h"
+@import Mapbox;
+
+NSString *const MBXExampleDDSCircleLayer = @"DDSCircleLayerExample";
+
+@interface DDSCircleLayerExample () <MGLMapViewDelegate>
+
+@property (nonatomic) MGLMapView *mapView;
+
+@end
+
+@implementation DDSCircleLayerExample
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    // Create a new map view using the Mapbox Light style.
+    self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds
+        styleURL:[MGLStyle lightStyleURLWithVersion:9]];
+    
+    self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    
+    // Set the map’s center coordinate and zoom level.
+    self.mapView.centerCoordinate = CLLocationCoordinate2DMake(38.897,-77.039);
+    self.mapView.zoomLevel = 10.5;
+    
+    self.mapView.delegate = self;
+    [self.view addSubview: self.mapView];
+}
+
+// Wait until the style is loaded before modifying the map style.
+- (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {
+    
+    // "mapbox://examples.2uf7qges" is a map ID referencing a tileset. For more
+    // more information, see mapbox.com/help/define-map-id/
+    MGLSource *source = [[MGLVectorSource alloc] initWithIdentifier:@"trees" configurationURL:[NSURL URLWithString:@"mapbox://examples.2uf7qges"]];
+    
+    [self.mapView.style addSource:source];
+    
+    MGLCircleStyleLayer *layer = [[MGLCircleStyleLayer alloc] initWithIdentifier: @"tree-style" source:source];
+    
+    // The source name from the source's TileJSON metadata: mapbox.com/api-documentation/#retrieve-tilejson-metadata
+    layer.sourceLayerIdentifier = @"yoshino-trees-a0puw5";
+    
+    // Stops based on age of tree in years.
+    NSDictionary *stops = @{
+        @0: [MGLStyleValue valueWithRawValue:[UIColor colorWithRed:1.00 green:0.72 blue:0.85 alpha:1.0]],
+        @2: [MGLStyleValue valueWithRawValue:[UIColor colorWithRed:0.69 green:0.48 blue:0.73 alpha:1.0]],
+        @4: [MGLStyleValue valueWithRawValue:[UIColor colorWithRed:0.61 green:0.31 blue:0.47 alpha:1.0]],
+        @7: [MGLStyleValue valueWithRawValue:[UIColor colorWithRed:0.43 green:0.20 blue:0.38 alpha:1.0]],
+        @16: [MGLStyleValue valueWithRawValue:[UIColor colorWithRed:0.33 green:0.17 blue:0.25 alpha:1.0]]
+    };
+    
+    // Style the circle layer color based on the above categorical stops.
+    layer.circleColor = [MGLStyleValue valueWithInterpolationMode: MGLInterpolationModeInterval
+        sourceStops: stops
+        attributeName: @"AGE"
+        options: nil];
+    
+    layer.circleRadius = [MGLStyleValue valueWithRawValue:@3];
+    
+    [self.mapView.style addLayer:layer];
+}
+
+@end

--- a/Examples/Swift/DDSCircleLayerExample.swift
+++ b/Examples/Swift/DDSCircleLayerExample.swift
@@ -1,0 +1,58 @@
+import Mapbox
+
+@objc(DDSCircleLayerExample_Swift)
+
+class DDSCircleLayerExample_Swift: UIViewController, MGLMapViewDelegate {
+    
+    var mapView: MGLMapView!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        // Create a new map view using the Mapbox Light style.
+        mapView = MGLMapView(frame: view.bounds)
+        mapView.styleURL = MGLStyle.lightStyleURL(withVersion: 9)
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        
+        // Set the map’s center coordinate and zoom level.
+        mapView.setCenter(CLLocationCoordinate2D(latitude: 38.897, longitude: -77.039), animated: false)
+        mapView.zoomLevel = 10.5
+
+        mapView.delegate = self
+        view.addSubview(mapView)
+    }
+    
+    // Wait until the style is loaded before modifying the map style.
+    func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
+        
+        // "mapbox://examples.2uf7qges" is a map ID referencing a tileset. For more
+        // more information, see mapbox.com/help/define-map-id/
+        let source = MGLVectorSource(identifier: "trees", configurationURL: URL(string: "mapbox://examples.2uf7qges")!)
+
+        style.addSource(source)
+
+        let layer = MGLCircleStyleLayer(identifier: "tree-style", source: source)
+
+        // The source name from the source's TileJSON metadata: mapbox.com/api-documentation/#retrieve-tilejson-metadata
+        layer.sourceLayerIdentifier = "yoshino-trees-a0puw5"
+        
+        // Stops based on age of tree in years.
+        let stops = [
+          0: MGLStyleValue(rawValue: UIColor(red:1.00, green:0.72, blue:0.85, alpha:1.0)),
+          2: MGLStyleValue(rawValue: UIColor(red:0.69, green:0.48, blue:0.73, alpha:1.0)),
+          4: MGLStyleValue(rawValue: UIColor(red:0.61, green:0.31, blue:0.47, alpha:1.0)),
+          7: MGLStyleValue(rawValue: UIColor(red:0.43, green:0.20, blue:0.38, alpha:1.0)),
+          16: MGLStyleValue(rawValue: UIColor(red:0.33, green:0.17, blue:0.25, alpha:1.0))
+        ]
+        
+        // Style the circle layer color based on the above categorical stops
+        layer.circleColor = MGLStyleValue<UIColor>(interpolationMode: .interval,
+            sourceStops: stops,
+            attributeName: "AGE",
+            options: nil)
+        
+        layer.circleRadius = MGLStyleValue(rawValue: 3)
+        
+        style.addLayer(layer)
+    }
+}


### PR DESCRIPTION
Add data driven styling example using `MGLCircleStyleLayer`.

<img width="667" alt="screen shot 2017-03-10 at 6 56 15 pm" src="https://cloud.githubusercontent.com/assets/10850812/23819967/78229fc8-05c3-11e7-99b5-363b48393d87.png">

cc @jmkiley 