### PR TITLE
[Example] DDS Feature Selection

### DIFF
--- a/Examples.xcodeproj/project.pbxproj
+++ b/Examples.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		07C138C41E721C8F00D6F678 /* DDSCircleLayerExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C138C31E721C8F00D6F678 /* DDSCircleLayerExample.swift */; };
 		07C138C71E72216E00D6F678 /* DDSCircleLayerExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 07C138C61E72216E00D6F678 /* DDSCircleLayerExample.m */; };
 		07F53B851E00D02100B58DB3 /* AnnotationViewMultipleExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 07F53B841E00D02100B58DB3 /* AnnotationViewMultipleExample.m */; };
+		3E3BFAD91E81D7A300D0BEA1 /* DDSLayerSelectionExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E3BFAD81E81D7A300D0BEA1 /* DDSLayerSelectionExample.swift */; };
+		3E3BFADC1E81D7BB00D0BEA1 /* DDSLayerSelectionExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E3BFADB1E81D7BB00D0BEA1 /* DDSLayerSelectionExample.m */; };
 		3EBCD7161DC28240001E342F /* AnnotationViewExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBCD7021DC28240001E342F /* AnnotationViewExample.swift */; };
 		3EBCD7171DC28240001E342F /* CalloutDelegateUsageExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBCD7031DC28240001E342F /* CalloutDelegateUsageExample.swift */; };
 		3EBCD7181DC28240001E342F /* CameraAnimationExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EBCD7041DC28240001E342F /* CameraAnimationExample.swift */; };
@@ -137,6 +139,9 @@
 		07F53B861E00D08600B58DB3 /* AnnotationViewMultipleExample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AnnotationViewMultipleExample.h; sourceTree = "<group>"; };
 		0A4917D6B62E749D739044A4 /* Pods-ExamplesUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExamplesUITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ExamplesUITests/Pods-ExamplesUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		29A0D7C8DCD539DCA5DA1BAC /* Pods-Examples.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Examples.release.xcconfig"; path = "Pods/Target Support Files/Pods-Examples/Pods-Examples.release.xcconfig"; sourceTree = "<group>"; };
+		3E3BFAD81E81D7A300D0BEA1 /* DDSLayerSelectionExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDSLayerSelectionExample.swift; sourceTree = "<group>"; };
+		3E3BFADA1E81D7BB00D0BEA1 /* DDSLayerSelectionExample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDSLayerSelectionExample.h; sourceTree = "<group>"; };
+		3E3BFADB1E81D7BB00D0BEA1 /* DDSLayerSelectionExample.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDSLayerSelectionExample.m; sourceTree = "<group>"; };
 		3EBCD7021DC28240001E342F /* AnnotationViewExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnnotationViewExample.swift; sourceTree = "<group>"; };
 		3EBCD7031DC28240001E342F /* CalloutDelegateUsageExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalloutDelegateUsageExample.swift; sourceTree = "<group>"; };
 		3EBCD7041DC28240001E342F /* CameraAnimationExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CameraAnimationExample.swift; sourceTree = "<group>"; };
@@ -307,6 +312,7 @@
 				968247021C5BDCBB00494AB8 /* CustomRasterStyleExample.m */,
 				9691AAA21C5AAD8F006A58C6 /* CustomStyleExample.m */,
 				07C138C61E72216E00D6F678 /* DDSCircleLayerExample.m */,
+				3E3BFADB1E81D7BB00D0BEA1 /* DDSLayerSelectionExample.m */,
 				9691AAA41C5AAD8F006A58C6 /* DefaultStylesExample.m */,
 				960A21601D344F9F00BB348B /* DraggableAnnotationViewExample.m */,
 				96D431FB1C84B4F7007D09D1 /* DrawingACustomMarkerExample.m */,
@@ -347,6 +353,7 @@
 				3EBCD7091DC28240001E342F /* CustomRasterStyleExample.swift */,
 				3EBCD70A1DC28240001E342F /* CustomStyleExample.swift */,
 				07C138C31E721C8F00D6F678 /* DDSCircleLayerExample.swift */,
+				3E3BFAD81E81D7A300D0BEA1 /* DDSLayerSelectionExample.swift */,
 				3EBCD70B1DC28240001E342F /* DefaultStylesExample.swift */,
 				3EBCD70C1DC28240001E342F /* DraggableAnnotationViewExample.swift */,
 				3EBCD70D1DC28240001E342F /* DrawingACustomMarkerExample.swift */,
@@ -473,6 +480,7 @@
 				968247011C5BDCBB00494AB8 /* CustomRasterStyleExample.h */,
 				9691AAA11C5AAD8F006A58C6 /* CustomStyleExample.h */,
 				07C138C51E72216D00D6F678 /* DDSCircleLayerExample.h */,
+				3E3BFADA1E81D7BB00D0BEA1 /* DDSLayerSelectionExample.h */,
 				9691AAA31C5AAD8F006A58C6 /* DefaultStylesExample.h */,
 				960A215F1D344F9F00BB348B /* DraggableAnnotationViewExample.h */,
 				96D431FA1C84B4F7007D09D1 /* DrawingACustomMarkerExample.h */,
@@ -870,6 +878,7 @@
 				96D431FC1C84B4F7007D09D1 /* DrawingACustomMarkerExample.m in Sources */,
 				968247031C5BDCBB00494AB8 /* CustomRasterStyleExample.m in Sources */,
 				64CF97121DF224F600C3C27B /* SourceCustomRasterExample.swift in Sources */,
+				3E3BFADC1E81D7BB00D0BEA1 /* DDSLayerSelectionExample.m in Sources */,
 				9682472A1C5C1FF800494AB8 /* PointConversionExample.m in Sources */,
 				3ED403481E006BE800230C95 /* CameraFlyToExample.m in Sources */,
 				3EBCD71D1DC28240001E342F /* CustomRasterStyleExample.swift in Sources */,
@@ -880,6 +889,7 @@
 				968247131C5C0F0F00494AB8 /* CalloutDelegateUsageExample.m in Sources */,
 				3EBCD7251DC28240001E342F /* OfflinePackExample.swift in Sources */,
 				3EBCD71A1DC28240001E342F /* CustomAnnotationModels.swift in Sources */,
+				3E3BFAD91E81D7A300D0BEA1 /* DDSLayerSelectionExample.swift in Sources */,
 				3EBCD7181DC28240001E342F /* CameraAnimationExample.swift in Sources */,
 				9691AA941C5AA702006A58C6 /* Examples.m in Sources */,
 				3EBCD7201DC28240001E342F /* DraggableAnnotationViewExample.swift in Sources */,

--- a/Examples/Examples.h
+++ b/Examples/Examples.h
@@ -25,6 +25,7 @@ extern NSString *const MBXExampleClustering;
 extern NSString *const MBXExampleCustomRasterStyle;
 extern NSString *const MBXExampleCustomStyle;
 extern NSString *const MBXExampleDDSCircleLayer;
+extern NSString *const MBXExampleDDSLayerSelection;
 extern NSString *const MBXExampleDefaultStyles;
 extern NSString *const MBXExampleDraggableAnnotationView;
 extern NSString *const MBXExampleDrawingAGeoJSONLine;

--- a/Examples/Examples.m
+++ b/Examples/Examples.m
@@ -24,6 +24,7 @@
         MBXExampleCustomRasterStyle,
         MBXExampleCustomStyle,
         MBXExampleDDSCircleLayer,
+        MBXExampleDDSLayerSelection,
         MBXExampleDefaultStyles,
         MBXExampleDraggableAnnotationView,
         MBXExampleDrawingAGeoJSONLine,

--- a/Examples/ObjectiveC/DDSLayerSelectionExample.h
+++ b/Examples/ObjectiveC/DDSLayerSelectionExample.h
@@ -1,0 +1,13 @@
+//
+//  DDSLayerSelectionExample.h
+//  Examples
+//
+//  Created by Jordan Kiley on 3/21/17.
+//  Copyright © 2017 Mapbox. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface DDSLayerSelectionExample : UIViewController
+
+@end

--- a/Examples/ObjectiveC/DDSLayerSelectionExample.m
+++ b/Examples/ObjectiveC/DDSLayerSelectionExample.m
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Mapbox. All rights reserved.
 //
 
-// url to use: mapbox://examples.69ytlgls
+// url to use: 
 
 #import "DDSLayerSelectionExample.h"
 @import Mapbox;

--- a/Examples/ObjectiveC/DDSLayerSelectionExample.m
+++ b/Examples/ObjectiveC/DDSLayerSelectionExample.m
@@ -16,7 +16,6 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
 @interface DDSLayerSelectionExample () <MGLMapViewDelegate, UIGestureRecognizerDelegate>
 
 @property (nonatomic) MGLMapView *mapView;
-@property (nonatomic) BOOL *isStateSelected;
 
 @end
 
@@ -33,31 +32,28 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
     
     UITapGestureRecognizer *gesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
     gesture.delegate = self;
+    gesture.numberOfTapsRequired = 1;
     [self.mapView addGestureRecognizer:gesture];
-    self.isStateSelected = FALSE;
 }
 
 - (void)handleTap:(UITapGestureRecognizer *)gesture {
     CGPoint spot = [gesture locationInView:self.mapView];
-    NSArray *features = [self.mapView visibleFeaturesAtPoint:spot];
+    NSArray *features = [self.mapView visibleFeaturesAtPoint:spot inStyleLayersWithIdentifiers:[NSSet setWithObject:@"state-layer"]];
     
     MGLPolygonFeature *feature = [features firstObject];
     
     NSString *state = [feature attributeForKey:@"name"];
-    [self changeOpacityBasedOn:state withCompletion:^(BOOL finished) {
-        self.isStateSelected = !self.isStateSelected;
-    }];
+    [self changeOpacityBasedOn:state];
 }
 
 
-- (void)changeOpacityBasedOn:(NSString*)name withCompletion:(void(^)(BOOL finished))completionHandler {
+- (void)changeOpacityBasedOn:(NSString*)name {
     MGLFillStyleLayer *layer = [self.mapView.style layerWithIdentifier:@"state-layer"];
-    if (!self.isStateSelected && [name length] > 0) {
+    if ([name length] > 0) {
         layer.fillOpacity = [MGLStyleValue valueWithInterpolationMode:MGLInterpolationModeCategorical sourceStops:@{name: [MGLStyleValue valueWithRawValue:@1]} attributeName:@"name" options:@{MGLStyleFunctionOptionDefaultValue: [MGLStyleValue valueWithRawValue:@0]}];
     } else {
         layer.fillOpacity = [MGLStyleValue valueWithRawValue:@1];
     }
-    completionHandler(TRUE);
 }
 
 - (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {

--- a/Examples/ObjectiveC/DDSLayerSelectionExample.m
+++ b/Examples/ObjectiveC/DDSLayerSelectionExample.m
@@ -16,7 +16,7 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
 @interface DDSLayerSelectionExample () <MGLMapViewDelegate, UIGestureRecognizerDelegate>
 
 @property (nonatomic) MGLMapView *mapView;
-@property (nonatomic) Boolean *isStateSelected;
+@property (nonatomic) BOOL *isStateSelected;
 
 @end
 
@@ -34,6 +34,7 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
     UITapGestureRecognizer *gesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
     gesture.delegate = self;
     [self.mapView addGestureRecognizer:gesture];
+    self.isStateSelected = FALSE;
 }
 
 - (void)handleTap:(UITapGestureRecognizer *)gesture {
@@ -43,11 +44,20 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
     MGLPolygonFeature *feature = [features firstObject];
     
     NSString *state = [feature attributeForKey:@"name"];
+    [self changeOpacityBasedOn:state withCompletion:^(BOOL finished) {
+        self.isStateSelected = !self.isStateSelected;
+    }];
 }
 
-// JK - I need to put in a block?
-- (void)changeOpacity:(NSString*)name {
-    
+
+- (void)changeOpacityBasedOn:(NSString*)name withCompletion:(void(^)(BOOL finished))completionHandler {
+    MGLFillStyleLayer *layer = [self.mapView.style layerWithIdentifier:@"state-layer"];
+    if (!self.isStateSelected) {
+        layer.fillOpacity = [MGLStyleValue valueWithInterpolationMode:MGLInterpolationModeCategorical sourceStops:@{name: [MGLStyleValue valueWithRawValue:@1]} attributeName:@"name" options:@{MGLStyleFunctionOptionDefaultValue: [MGLStyleValue valueWithRawValue:@0]}];
+    } else {
+        layer.fillOpacity = [MGLStyleValue valueWithRawValue:@1];
+    }
+    completionHandler(TRUE);
 }
 
 - (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {

--- a/Examples/ObjectiveC/DDSLayerSelectionExample.m
+++ b/Examples/ObjectiveC/DDSLayerSelectionExample.m
@@ -1,0 +1,27 @@
+//
+//  DDSLayerSelectionExample.m
+//  Examples
+//
+//  Created by Jordan Kiley on 3/21/17.
+//  Copyright © 2017 Mapbox. All rights reserved.
+//
+
+// url to use: mapbox://examples.69ytlgls
+
+#import "DDSLayerSelectionExample.h"
+@import Mapbox;
+
+NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
+
+@interface DDSLayerSelectionExample ()
+
+@end
+
+@implementation DDSLayerSelectionExample
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+}
+
+@end

--- a/Examples/ObjectiveC/DDSLayerSelectionExample.m
+++ b/Examples/ObjectiveC/DDSLayerSelectionExample.m
@@ -73,7 +73,7 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
                             };
     layer.fillColor = [MGLStyleValue valueWithInterpolationMode:MGLInterpolationModeExponential sourceStops:stops attributeName:@"density" options:@{MGLStyleFunctionOptionDefaultValue : [MGLStyleValue valueWithRawValue:[UIColor whiteColor]]}];
     
-    MGLStyleLayer *symbolLayer = [style layerWithIdentifier:@"state-label-sm"];
+    MGLStyleLayer *symbolLayer = [style layerWithIdentifier:@"place-city-sm"];
     
     [style insertLayer:layer belowLayer:symbolLayer];
 }

--- a/Examples/ObjectiveC/DDSLayerSelectionExample.m
+++ b/Examples/ObjectiveC/DDSLayerSelectionExample.m
@@ -1,12 +1,3 @@
-//
-//  DDSLayerSelectionExample.m
-//  Examples
-//
-//  Created by Jordan Kiley on 3/21/17.
-//  Copyright © 2017 Mapbox. All rights reserved.
-//
-
-// url to use: 
 
 #import "DDSLayerSelectionExample.h"
 @import Mapbox;
@@ -26,7 +17,7 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
     
     self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
     self.mapView.delegate = self;
-    [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(39.232253141714885,-97.91015624999999)];
+    [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(39.23225,-97.91015)];
     
     self.mapView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     [self.view addSubview:self.mapView];
@@ -40,7 +31,7 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
 
 - (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {
     
-    // Load a tileset containing U.S. states and their population density.
+    // Load a tileset containing U.S. states and their population density. For more information about working with tilesets, see: https://www.mapbox.com/help/studio-manual-tilesets/
     NSURL *url = [NSURL URLWithString:@"mapbox://examples.69ytlgls"];
     
     MGLVectorSource *source = [[MGLVectorSource alloc] initWithIdentifier:@"state-source" configurationURL:url];
@@ -53,15 +44,18 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
     
     // Create a stops dictionary. This defines the relationship between population density and a UIColor.
     NSDictionary *stops = @{
-                            @0: [MGLStyleValue valueWithRawValue:[UIColor yellowColor]],
-                            @600: [MGLStyleValue valueWithRawValue:[UIColor redColor]],
-                            @1200: [MGLStyleValue valueWithRawValue:[UIColor blueColor]]
-                            };
+            @0: [MGLStyleValue valueWithRawValue:[UIColor yellowColor]],
+            @600: [MGLStyleValue valueWithRawValue:[UIColor redColor]],
+            @1200: [MGLStyleValue valueWithRawValue:[UIColor blueColor]]
+        };
     
     // Style the fill color using the stops dictionary, exponential interpolation mode, and the feature attribute name.
-    layer.fillColor = [MGLStyleValue valueWithInterpolationMode:MGLInterpolationModeExponential sourceStops:stops attributeName:@"density" options:@{MGLStyleFunctionOptionDefaultValue : [MGLStyleValue valueWithRawValue:[UIColor whiteColor]]}];
+    layer.fillColor = [MGLStyleValue valueWithInterpolationMode:MGLInterpolationModeExponential
+            sourceStops:stops
+            attributeName:@"density"
+            options:@{MGLStyleFunctionOptionDefaultValue : [MGLStyleValue valueWithRawValue:[UIColor whiteColor]]}];
     
-    // Insert the new layer below the layer that contains state border lines.
+    // Insert the new layer below the Mapbox Streets layer that contains state border lines. See the layer reference for more information about layer names: https://www.mapbox.com/vector-tiles/mapbox-streets-v7/
     MGLStyleLayer *symbolLayer = [style layerWithIdentifier:@"admin-3-4-boundaries"];
     
     [style insertLayer:layer belowLayer:symbolLayer];
@@ -73,7 +67,8 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
     CGPoint spot = [gesture locationInView:self.mapView];
     
     // Access the features at that point within the state layer.
-    NSArray *features = [self.mapView visibleFeaturesAtPoint:spot inStyleLayersWithIdentifiers:[NSSet setWithObject:@"state-layer"]];
+    NSArray *features = [self.mapView visibleFeaturesAtPoint:spot
+            inStyleLayersWithIdentifiers:[NSSet setWithObject:@"state-layer"]];
     
     MGLPolygonFeature *feature = [features firstObject];
     
@@ -89,7 +84,10 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
     
     // Check if a state was selected, then change the opacity of the states that were not selected.
     if ([name length] > 0) {
-        layer.fillOpacity = [MGLStyleValue valueWithInterpolationMode:MGLInterpolationModeCategorical sourceStops:@{name: [MGLStyleValue valueWithRawValue:@1]} attributeName:@"name" options:@{MGLStyleFunctionOptionDefaultValue: [MGLStyleValue valueWithRawValue:@0]}];
+        layer.fillOpacity = [MGLStyleValue valueWithInterpolationMode:MGLInterpolationModeCategorical
+                sourceStops:@{name: [MGLStyleValue valueWithRawValue:@1]}
+                attributeName:@"name"
+                options:@{MGLStyleFunctionOptionDefaultValue: [MGLStyleValue valueWithRawValue:@0]}];
     } else {
         
         // Reset the opacity for all states if the user did not tap on a state.

--- a/Examples/ObjectiveC/DDSLayerSelectionExample.m
+++ b/Examples/ObjectiveC/DDSLayerSelectionExample.m
@@ -67,9 +67,9 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
     layer.sourceLayerIdentifier = @"stateData_2-dx853g";
     
     NSDictionary *stops = @{
-                            @0: [MGLStyleValue valueWithRawValue:[UIColor yellowColor]],
-                            @100: [MGLStyleValue valueWithRawValue:[UIColor redColor]],
-                            @1200: [MGLStyleValue valueWithRawValue:[UIColor blueColor]]
+                            @0: [MGLStyleValue valueWithRawValue:[UIColor colorWithRed:0.94 green:0.93 blue:0.96 alpha:1.0]],
+                            @600: [MGLStyleValue valueWithRawValue:[UIColor colorWithRed:0.62 green:0.60 blue:0.78 alpha:1.0]],
+                            @1200: [MGLStyleValue valueWithRawValue:[UIColor colorWithRed:0.33 green:0.15 blue:0.56 alpha:1.0]]
                             };
     layer.fillColor = [MGLStyleValue valueWithInterpolationMode:MGLInterpolationModeExponential sourceStops:stops attributeName:@"density" options:@{MGLStyleFunctionOptionDefaultValue : [MGLStyleValue valueWithRawValue:[UIColor whiteColor]]}];
     

--- a/Examples/ObjectiveC/DDSLayerSelectionExample.m
+++ b/Examples/ObjectiveC/DDSLayerSelectionExample.m
@@ -36,7 +36,7 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
     
     MGLVectorSource *source = [[MGLVectorSource alloc] initWithIdentifier:@"state-source" configurationURL:url];
     [style addSource:source];
-    
+
     MGLFillStyleLayer *layer = [[MGLFillStyleLayer alloc] initWithIdentifier:@"state-layer" source:source];
     
     // Access the tileset layer.
@@ -53,7 +53,7 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
     layer.fillColor = [MGLStyleValue valueWithInterpolationMode:MGLInterpolationModeExponential
             sourceStops:stops
             attributeName:@"density"
-            options:@{MGLStyleFunctionOptionDefaultValue : [MGLStyleValue valueWithRawValue:[UIColor whiteColor]]}];
+            options:@{MGLStyleFunctionOptionDefaultValue: [MGLStyleValue valueWithRawValue:[UIColor whiteColor]]}];
     
     // Insert the new layer below the Mapbox Streets layer that contains state border lines. See the layer reference for more information about layer names: https://www.mapbox.com/vector-tiles/mapbox-streets-v7/
     MGLStyleLayer *symbolLayer = [style layerWithIdentifier:@"admin-3-4-boundaries"];
@@ -70,7 +70,7 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
     NSArray *features = [self.mapView visibleFeaturesAtPoint:spot
             inStyleLayersWithIdentifiers:[NSSet setWithObject:@"state-layer"]];
     
-    MGLPolygonFeature *feature = [features firstObject];
+    MGLPolygonFeature *feature = features.firstObject;
     
     // Get the name of the selected state.
     NSString *state = [feature attributeForKey:@"name"];
@@ -83,7 +83,7 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
     MGLFillStyleLayer *layer = [self.mapView.style layerWithIdentifier:@"state-layer"];
     
     // Check if a state was selected, then change the opacity of the states that were not selected.
-    if ([name length] > 0) {
+    if (name.length > 0) {
         layer.fillOpacity = [MGLStyleValue valueWithInterpolationMode:MGLInterpolationModeCategorical
                 sourceStops:@{name: [MGLStyleValue valueWithRawValue:@1]}
                 attributeName:@"name"

--- a/Examples/ObjectiveC/DDSLayerSelectionExample.m
+++ b/Examples/ObjectiveC/DDSLayerSelectionExample.m
@@ -13,7 +13,10 @@
 
 NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
 
-@interface DDSLayerSelectionExample ()
+@interface DDSLayerSelectionExample () <MGLMapViewDelegate, UIGestureRecognizerDelegate>
+
+@property (nonatomic) MGLMapView *mapView;
+@property (nonatomic) Boolean *isStateSelected;
 
 @end
 
@@ -21,7 +24,33 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    // Do any additional setup after loading the view.
+    
+    self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
+    self.mapView.delegate = self;
+    
+    self.mapView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
+    [self.view addSubview:self.mapView];
+    
+    UITapGestureRecognizer *gesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:nil];
+    gesture.delegate = self;
+    [self.mapView addGestureRecognizer:gesture];
+}
+
+- (void)handleTap:(UITapGestureRecognizer *)gesture {
+    CGPoint spot = [gesture locationInView:self.mapView];
+    NSArray *features = [self.mapView visibleFeaturesAtPoint:spot];
+    
+    MGLPolygonFeature *feature = [features firstObject];
+    
+    NSString *state = [feature attributeForKey:@"name"];
+}
+
+// JK - I need to put in a block?
+- (void)changeOpacityForFeatureWith:(NSString*)name completion:^(BOOL finished) {
+    
+}
+- (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {
+    
 }
 
 @end

--- a/Examples/ObjectiveC/DDSLayerSelectionExample.m
+++ b/Examples/ObjectiveC/DDSLayerSelectionExample.m
@@ -31,7 +31,7 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
     self.mapView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     [self.view addSubview:self.mapView];
     
-    UITapGestureRecognizer *gesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:nil];
+    UITapGestureRecognizer *gesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
     gesture.delegate = self;
     [self.mapView addGestureRecognizer:gesture];
 }
@@ -46,11 +46,30 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
 }
 
 // JK - I need to put in a block?
-- (void)changeOpacityForFeatureWith:(NSString*)name completion:^(BOOL finished) {
+- (void)changeOpacity:(NSString*)name {
     
 }
+
 - (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {
     
+    NSURL *url = [NSURL URLWithString:@"mapbox://examples.69ytlgls"];
+    
+    MGLVectorSource *source = [[MGLVectorSource alloc] initWithIdentifier:@"state-source" configurationURL:url];
+    [style addSource:source];
+    
+    MGLFillStyleLayer *layer = [[MGLFillStyleLayer alloc] initWithIdentifier:@"state-layer" source:source];
+    layer.sourceLayerIdentifier = @"stateData_2-dx853g";
+    
+    NSDictionary *stops = @{
+                            @0: [MGLStyleValue valueWithRawValue:[UIColor yellowColor]],
+                            @100: [MGLStyleValue valueWithRawValue:[UIColor redColor]],
+                            @1200: [MGLStyleValue valueWithRawValue:[UIColor blueColor]]
+                            };
+    layer.fillColor = [MGLStyleValue valueWithInterpolationMode:MGLInterpolationModeExponential sourceStops:stops attributeName:@"density" options:@{MGLStyleFunctionOptionDefaultValue : [MGLStyleValue valueWithRawValue:[UIColor whiteColor]]}];
+    
+    MGLStyleLayer *symbolLayer = [style layerWithIdentifier:@"state-label-sm"];
+    
+    [style insertLayer:layer belowLayer:symbolLayer];
 }
 
 @end

--- a/Examples/ObjectiveC/DDSLayerSelectionExample.m
+++ b/Examples/ObjectiveC/DDSLayerSelectionExample.m
@@ -52,7 +52,7 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
 
 - (void)changeOpacityBasedOn:(NSString*)name withCompletion:(void(^)(BOOL finished))completionHandler {
     MGLFillStyleLayer *layer = [self.mapView.style layerWithIdentifier:@"state-layer"];
-    if (!self.isStateSelected) {
+    if (!self.isStateSelected && [name length] > 0) {
         layer.fillOpacity = [MGLStyleValue valueWithInterpolationMode:MGLInterpolationModeCategorical sourceStops:@{name: [MGLStyleValue valueWithRawValue:@1]} attributeName:@"name" options:@{MGLStyleFunctionOptionDefaultValue: [MGLStyleValue valueWithRawValue:@0]}];
     } else {
         layer.fillOpacity = [MGLStyleValue valueWithRawValue:@1];

--- a/Examples/ObjectiveC/DDSLayerSelectionExample.m
+++ b/Examples/ObjectiveC/DDSLayerSelectionExample.m
@@ -26,56 +26,75 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
     
     self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
     self.mapView.delegate = self;
+    [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(39.232253141714885,-97.91015624999999)];
     
     self.mapView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     [self.view addSubview:self.mapView];
     
+    // Add a tap gesture recognizer to the map view.
     UITapGestureRecognizer *gesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
     gesture.delegate = self;
     gesture.numberOfTapsRequired = 1;
     [self.mapView addGestureRecognizer:gesture];
 }
 
-- (void)handleTap:(UITapGestureRecognizer *)gesture {
-    CGPoint spot = [gesture locationInView:self.mapView];
-    NSArray *features = [self.mapView visibleFeaturesAtPoint:spot inStyleLayersWithIdentifiers:[NSSet setWithObject:@"state-layer"]];
-    
-    MGLPolygonFeature *feature = [features firstObject];
-    
-    NSString *state = [feature attributeForKey:@"name"];
-    [self changeOpacityBasedOn:state];
-}
-
-
-- (void)changeOpacityBasedOn:(NSString*)name {
-    MGLFillStyleLayer *layer = [self.mapView.style layerWithIdentifier:@"state-layer"];
-    if ([name length] > 0) {
-        layer.fillOpacity = [MGLStyleValue valueWithInterpolationMode:MGLInterpolationModeCategorical sourceStops:@{name: [MGLStyleValue valueWithRawValue:@1]} attributeName:@"name" options:@{MGLStyleFunctionOptionDefaultValue: [MGLStyleValue valueWithRawValue:@0]}];
-    } else {
-        layer.fillOpacity = [MGLStyleValue valueWithRawValue:@1];
-    }
-}
-
 - (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {
     
+    // Load a tileset containing U.S. states and their population density.
     NSURL *url = [NSURL URLWithString:@"mapbox://examples.69ytlgls"];
     
     MGLVectorSource *source = [[MGLVectorSource alloc] initWithIdentifier:@"state-source" configurationURL:url];
     [style addSource:source];
     
     MGLFillStyleLayer *layer = [[MGLFillStyleLayer alloc] initWithIdentifier:@"state-layer" source:source];
+    
+    // Access the tileset layer.
     layer.sourceLayerIdentifier = @"stateData_2-dx853g";
     
+    // Create a stops dictionary. This defines the relationship between population density and a UIColor.
     NSDictionary *stops = @{
-                            @0: [MGLStyleValue valueWithRawValue:[UIColor colorWithRed:0.94 green:0.93 blue:0.96 alpha:1.0]],
-                            @600: [MGLStyleValue valueWithRawValue:[UIColor colorWithRed:0.62 green:0.60 blue:0.78 alpha:1.0]],
-                            @1200: [MGLStyleValue valueWithRawValue:[UIColor colorWithRed:0.33 green:0.15 blue:0.56 alpha:1.0]]
+                            @0: [MGLStyleValue valueWithRawValue:[UIColor yellowColor]],
+                            @600: [MGLStyleValue valueWithRawValue:[UIColor redColor]],
+                            @1200: [MGLStyleValue valueWithRawValue:[UIColor blueColor]]
                             };
+    
+    // Style the fill color using the stops dictionary, exponential interpolation mode, and the feature attribute name.
     layer.fillColor = [MGLStyleValue valueWithInterpolationMode:MGLInterpolationModeExponential sourceStops:stops attributeName:@"density" options:@{MGLStyleFunctionOptionDefaultValue : [MGLStyleValue valueWithRawValue:[UIColor whiteColor]]}];
     
-    MGLStyleLayer *symbolLayer = [style layerWithIdentifier:@"place-city-sm"];
+    // Insert the new layer below the layer that contains state border lines.
+    MGLStyleLayer *symbolLayer = [style layerWithIdentifier:@"admin-3-4-boundaries"];
     
     [style insertLayer:layer belowLayer:symbolLayer];
+}
+
+- (void)handleTap:(UITapGestureRecognizer *)gesture {
+    
+    // Get the CGPoint where the user tapped.
+    CGPoint spot = [gesture locationInView:self.mapView];
+    
+    // Access the features at that point within the state layer.
+    NSArray *features = [self.mapView visibleFeaturesAtPoint:spot inStyleLayersWithIdentifiers:[NSSet setWithObject:@"state-layer"]];
+    
+    MGLPolygonFeature *feature = [features firstObject];
+    
+    // Get the name of the selected state.
+    NSString *state = [feature attributeForKey:@"name"];
+    
+    [self changeOpacityBasedOn:state];
+}
+
+- (void)changeOpacityBasedOn:(NSString*)name {
+    
+    MGLFillStyleLayer *layer = [self.mapView.style layerWithIdentifier:@"state-layer"];
+    
+    // Check if a state was selected, then change the opacity of the states that were not selected.
+    if ([name length] > 0) {
+        layer.fillOpacity = [MGLStyleValue valueWithInterpolationMode:MGLInterpolationModeCategorical sourceStops:@{name: [MGLStyleValue valueWithRawValue:@1]} attributeName:@"name" options:@{MGLStyleFunctionOptionDefaultValue: [MGLStyleValue valueWithRawValue:@0]}];
+    } else {
+        
+        // Reset the opacity for all states if the user did not tap on a state.
+        layer.fillOpacity = [MGLStyleValue valueWithRawValue:@1];
+    }
 }
 
 @end

--- a/Examples/Swift/DDSLayerSelectionExample.swift
+++ b/Examples/Swift/DDSLayerSelectionExample.swift
@@ -1,10 +1,3 @@
-//
-//  DDSLayerSelectionExample.swift
-//  Examples
-//
-//  Created by Jordan Kiley on 3/21/17.
-//  Copyright © 2017 Mapbox. All rights reserved.
-//
 
 import Mapbox
 
@@ -19,7 +12,7 @@ class DDSLayerSelectionExample_Swift: UIViewController, MGLMapViewDelegate, UIGe
         
         mapView = MGLMapView(frame: view.bounds)
         mapView.delegate = self
-        mapView.setCenter(CLLocationCoordinate2D(latitude:39.232253141714885, longitude:-97.91015624999999), animated: false)
+        mapView.setCenter(CLLocationCoordinate2D(latitude:39.23225, longitude:-97.91015), animated: false)
         mapView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         view.addSubview(mapView)
         
@@ -31,7 +24,7 @@ class DDSLayerSelectionExample_Swift: UIViewController, MGLMapViewDelegate, UIGe
     
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
         
-        // Load a tileset containing U.S. states and their population density.
+    // Load a tileset containing U.S. states and their population density. For more information about working with tilesets, see: https://www.mapbox.com/help/studio-manual-tilesets/
         let url = URL(string: "mapbox://examples.69ytlgls")!
         let source = MGLVectorSource(identifier: "state-source", configurationURL: url)
         style.addSource(source)
@@ -49,7 +42,7 @@ class DDSLayerSelectionExample_Swift: UIViewController, MGLMapViewDelegate, UIGe
         // Style the fill color using the stops dictionary, exponential interpolation mode, and the feature attribute name.
         layer.fillColor = MGLStyleValue(interpolationMode: .exponential, sourceStops: stops, attributeName: "density", options: [.defaultValue : MGLStyleValue(rawValue: UIColor.white)])
         
-        // Insert the new layer below the layer that contains state border lines.
+        // Insert the new layer below the Mapbox Streets layer that contains state border lines. See the layer reference for more information about layer names: https://www.mapbox.com/vector-tiles/mapbox-streets-v7/
         let symbolLayer = style.layer(withIdentifier: "admin-3-4-boundaries")
         style.insertLayer(layer, below: symbolLayer!)
     }

--- a/Examples/Swift/DDSLayerSelectionExample.swift
+++ b/Examples/Swift/DDSLayerSelectionExample.swift
@@ -40,7 +40,7 @@ class DDSLayerSelectionExample_Swift: UIViewController, MGLMapViewDelegate, UIGe
                      1200: MGLStyleValue(rawValue: UIColor.blue)]
         
         // Style the fill color using the stops dictionary, exponential interpolation mode, and the feature attribute name.
-        layer.fillColor = MGLStyleValue(interpolationMode: .exponential, sourceStops: stops, attributeName: "density", options: [.defaultValue : MGLStyleValue(rawValue: UIColor.white)])
+        layer.fillColor = MGLStyleValue(interpolationMode: .exponential, sourceStops: stops, attributeName: "density", options: [.defaultValue: MGLStyleValue(rawValue: UIColor.white)])
         
         // Insert the new layer below the Mapbox Streets layer that contains state border lines. See the layer reference for more information about layer names: https://www.mapbox.com/vector-tiles/mapbox-streets-v7/
         let symbolLayer = style.layer(withIdentifier: "admin-3-4-boundaries")
@@ -68,7 +68,7 @@ class DDSLayerSelectionExample_Swift: UIViewController, MGLMapViewDelegate, UIGe
         
         // Check if a state was selected, then change the opacity of the states that were not selected.
         if name.characters.count > 0 {
-            layer.fillOpacity = MGLStyleValue(interpolationMode: .categorical, sourceStops: [name : MGLStyleValue<NSNumber>(rawValue: 1)], attributeName: "name", options: [.defaultValue : MGLStyleValue<NSNumber>(rawValue: 0)])
+            layer.fillOpacity = MGLStyleValue(interpolationMode: .categorical, sourceStops: [name: MGLStyleValue<NSNumber>(rawValue: 1)], attributeName: "name", options: [.defaultValue: MGLStyleValue<NSNumber>(rawValue: 0)])
         } else {
             // Reset the opacity for all states if the user did not tap on a state.
             layer.fillOpacity = MGLStyleValue(rawValue: 1)

--- a/Examples/Swift/DDSLayerSelectionExample.swift
+++ b/Examples/Swift/DDSLayerSelectionExample.swift
@@ -13,8 +13,7 @@ import Mapbox
 class DDSLayerSelectionExample_Swift: UIViewController, MGLMapViewDelegate, UIGestureRecognizerDelegate {
     
     var mapView : MGLMapView!
-    var isStateSelected : Bool = false
-    
+ 
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -33,22 +32,20 @@ class DDSLayerSelectionExample_Swift: UIViewController, MGLMapViewDelegate, UIGe
         let features = mapView.visibleFeatures(at: spot, styleLayerIdentifiers: Set(["state-layer"]))
         
         if let feature = features.first, let state = feature.attribute(forKey: "name") as? String{
-            changeOpacity(name: state, finished: {
-                isStateSelected = !isStateSelected
-            })
+            changeOpacity(name: state)
+        } else {
+            changeOpacity(name: "")
         }
     }
     
-    func changeOpacity(name: String, finished: ()->()) {
-        
+    func changeOpacity(name: String) {
         let layer = mapView.style?.layer(withIdentifier: "state-layer") as! MGLFillStyleLayer
-        if !isStateSelected  && name.characters.count > 0 {
-                layer.fillOpacity = MGLStyleValue(interpolationMode: .categorical, sourceStops: [name : MGLStyleValue<NSNumber>(rawValue: 1)], attributeName: "name", options: [.defaultValue : MGLStyleValue<NSNumber>(rawValue: 0)])
-        
+        if name.characters.count > 0 {
+            layer.fillOpacity = MGLStyleValue(interpolationMode: .categorical, sourceStops: [name : MGLStyleValue<NSNumber>(rawValue: 1)], attributeName: "name", options: [.defaultValue : MGLStyleValue<NSNumber>(rawValue: 0)])
+            
         } else {
             layer.fillOpacity = MGLStyleValue(rawValue: 1)
         }
-        finished()
     }
     
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {

--- a/Examples/Swift/DDSLayerSelectionExample.swift
+++ b/Examples/Swift/DDSLayerSelectionExample.swift
@@ -57,9 +57,9 @@ class DDSLayerSelectionExample_Swift: UIViewController, MGLMapViewDelegate, UIGe
         let layer = MGLFillStyleLayer(identifier: "state-layer", source: source)
         layer.sourceLayerIdentifier = "stateData_2-dx853g"
         let stops = [
-            0: MGLStyleValue(rawValue: UIColor(red:0.94, green:0.93, blue:0.96, alpha:1.0)),
-            600: MGLStyleValue(rawValue: UIColor(red:0.62, green:0.60, blue:0.78, alpha:1.0)),
-            1200: MGLStyleValue(rawValue: UIColor(red:0.33, green:0.15, blue:0.56, alpha:1.0))]
+            0: MGLStyleValue<UIColor>(rawValue: UIColor(red:0.94, green:0.93, blue:0.96, alpha:1.0)),
+            600: MGLStyleValue<UIColor>(rawValue: UIColor(red:0.62, green:0.60, blue:0.78, alpha:1.0)),
+            1200: MGLStyleValue<UIColor>(rawValue: UIColor(red:0.33, green:0.15, blue:0.56, alpha:1.0))]
         
         layer.fillColor = MGLStyleValue(interpolationMode: .exponential, sourceStops: stops, attributeName: "density", options: [.defaultValue : MGLStyleValue(rawValue: .white)])
         let symbolLayer = style.layer(withIdentifier: "place-city-sm")

--- a/Examples/Swift/DDSLayerSelectionExample.swift
+++ b/Examples/Swift/DDSLayerSelectionExample.swift
@@ -42,10 +42,9 @@ class DDSLayerSelectionExample_Swift: UIViewController, MGLMapViewDelegate, UIGe
     func changeOpacity(name: String, finished: ()->()) {
         
         let layer = mapView.style?.layer(withIdentifier: "state-layer") as! MGLFillStyleLayer
-        if !isStateSelected {
-            if name.characters.count > 0 {
+        if !isStateSelected  && name.characters.count > 0 {
                 layer.fillOpacity = MGLStyleValue(interpolationMode: .categorical, sourceStops: [name : MGLStyleValue<NSNumber>(rawValue: 1)], attributeName: "name", options: [.defaultValue : MGLStyleValue<NSNumber>(rawValue: 0)])
-            }
+        
         } else {
             layer.fillOpacity = MGLStyleValue(rawValue: 1)
         }

--- a/Examples/Swift/DDSLayerSelectionExample.swift
+++ b/Examples/Swift/DDSLayerSelectionExample.swift
@@ -1,0 +1,25 @@
+//
+//  DDSLayerSelectionExample.swift
+//  Examples
+//
+//  Created by Jordan Kiley on 3/21/17.
+//  Copyright © 2017 Mapbox. All rights reserved.
+//
+
+import Mapbox
+
+@objc(DDSLayerSelectionExample_Swift)
+
+class DDSLayerSelectionExample_Swift: UIViewController, MGLMapViewDelegate {
+    
+    var mapView : MGLMapView!
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        mapView = MGLMapView(frame: view.bounds)
+        mapView.delegate = self
+        
+        view.addSubview(mapView)
+    }
+    
+}

--- a/Examples/Swift/DDSLayerSelectionExample.swift
+++ b/Examples/Swift/DDSLayerSelectionExample.swift
@@ -61,7 +61,7 @@ class DDSLayerSelectionExample_Swift: UIViewController, MGLMapViewDelegate, UIGe
                      1200: MGLStyleValue<UIColor>(rawValue: .blue)]
         
         layer.fillColor = MGLStyleValue(interpolationMode: .exponential, sourceStops: stops, attributeName: "density", options: [.defaultValue : MGLStyleValue<UIColor>(rawValue: .white)])
-        let symbolLayer = style.layer(withIdentifier: "state-label-sm")
+        let symbolLayer = style.layer(withIdentifier: "place-city-sm")
         style.insertLayer(layer, below: symbolLayer!)
     }
 }

--- a/Examples/Swift/DDSLayerSelectionExample.swift
+++ b/Examples/Swift/DDSLayerSelectionExample.swift
@@ -10,16 +10,64 @@ import Mapbox
 
 @objc(DDSLayerSelectionExample_Swift)
 
-class DDSLayerSelectionExample_Swift: UIViewController, MGLMapViewDelegate {
+class DDSLayerSelectionExample_Swift: UIViewController, MGLMapViewDelegate, UIGestureRecognizerDelegate {
     
     var mapView : MGLMapView!
+    var isStateSelected : Bool = false
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
         mapView = MGLMapView(frame: view.bounds)
         mapView.delegate = self
-        
+        mapView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         view.addSubview(mapView)
+        
+        let gesture = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
+        gesture.delegate = self
+        mapView.addGestureRecognizer(gesture)
     }
     
+    func handleTap(_ gesture: UITapGestureRecognizer) {
+        let spot = gesture.location(in: mapView)
+        let features = mapView.visibleFeatures(at: spot, styleLayerIdentifiers: Set(["state-layer"]))
+        
+        if let feature = features.first, let state = feature.attribute(forKey: "name") as? String{
+            changeOpacity(name: state, finished: {
+                isStateSelected = !isStateSelected
+            })
+        }
+    }
+    
+    func changeOpacity(name: String, finished: ()->()) {
+        
+        let layer = mapView.style?.layer(withIdentifier: "state-layer") as! MGLFillStyleLayer
+        if !isStateSelected {
+            if name.characters.count > 0 {
+                layer.fillOpacity = MGLStyleValue(interpolationMode: .categorical, sourceStops: [name : MGLStyleValue<NSNumber>(rawValue: 1)], attributeName: "name", options: [.defaultValue : MGLStyleValue<NSNumber>(rawValue: 0)])
+            }
+        } else {
+            layer.fillOpacity = MGLStyleValue(rawValue: 1)
+        }
+        finished()
+    }
+    
+    func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
+        
+        let symbolLayer = style.layer(withIdentifier: "state-label-sm")
+        
+        let url = URL(string: "mapbox://examples.69ytlgls")!
+        let source = MGLVectorSource(identifier: "state-source", configurationURL: url)
+        style.addSource(source)
+        
+        let layer = MGLFillStyleLayer(identifier: "state-layer", source: source)
+        layer.sourceLayerIdentifier = "stateData_2-dx853g"
+        let stops = [0: MGLStyleValue<UIColor>(rawValue: .yellow),
+                     100: MGLStyleValue<UIColor>(rawValue: .red),
+                     1200: MGLStyleValue<UIColor>(rawValue: .blue)]
+        
+        layer.fillColor = MGLStyleValue(interpolationMode: .exponential, sourceStops: stops, attributeName: "density", options: [.defaultValue : MGLStyleValue<UIColor>(rawValue: .blue)])
+        
+        style.insertLayer(layer, below: symbolLayer!)
+    }
 }

--- a/Examples/Swift/DDSLayerSelectionExample.swift
+++ b/Examples/Swift/DDSLayerSelectionExample.swift
@@ -54,8 +54,6 @@ class DDSLayerSelectionExample_Swift: UIViewController, MGLMapViewDelegate, UIGe
     
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
         
-        let symbolLayer = style.layer(withIdentifier: "state-label-sm")
-        
         let url = URL(string: "mapbox://examples.69ytlgls")!
         let source = MGLVectorSource(identifier: "state-source", configurationURL: url)
         style.addSource(source)
@@ -66,8 +64,8 @@ class DDSLayerSelectionExample_Swift: UIViewController, MGLMapViewDelegate, UIGe
                      100: MGLStyleValue<UIColor>(rawValue: .red),
                      1200: MGLStyleValue<UIColor>(rawValue: .blue)]
         
-        layer.fillColor = MGLStyleValue(interpolationMode: .exponential, sourceStops: stops, attributeName: "density", options: [.defaultValue : MGLStyleValue<UIColor>(rawValue: .blue)])
-        
+        layer.fillColor = MGLStyleValue(interpolationMode: .exponential, sourceStops: stops, attributeName: "density", options: [.defaultValue : MGLStyleValue<UIColor>(rawValue: .white)])
+        let symbolLayer = style.layer(withIdentifier: "state-label-sm")
         style.insertLayer(layer, below: symbolLayer!)
     }
 }

--- a/Examples/Swift/DDSLayerSelectionExample.swift
+++ b/Examples/Swift/DDSLayerSelectionExample.swift
@@ -54,7 +54,6 @@ class DDSLayerSelectionExample_Swift: UIViewController, MGLMapViewDelegate, UIGe
         style.insertLayer(layer, below: symbolLayer!)
     }
     
-    
     func handleTap(_ gesture: UITapGestureRecognizer) {
         
         // Get the CGPoint where the user tapped.

--- a/Examples/Swift/DDSLayerSelectionExample.swift
+++ b/Examples/Swift/DDSLayerSelectionExample.swift
@@ -69,9 +69,7 @@ class DDSLayerSelectionExample_Swift: UIViewController, MGLMapViewDelegate, UIGe
         // Check if a state was selected, then change the opacity of the states that were not selected.
         if name.characters.count > 0 {
             layer.fillOpacity = MGLStyleValue(interpolationMode: .categorical, sourceStops: [name : MGLStyleValue<NSNumber>(rawValue: 1)], attributeName: "name", options: [.defaultValue : MGLStyleValue<NSNumber>(rawValue: 0)])
-            
         } else {
-            
             // Reset the opacity for all states if the user did not tap on a state.
             layer.fillOpacity = MGLStyleValue(rawValue: 1)
         }

--- a/Examples/Swift/DDSLayerSelectionExample.swift
+++ b/Examples/Swift/DDSLayerSelectionExample.swift
@@ -56,11 +56,12 @@ class DDSLayerSelectionExample_Swift: UIViewController, MGLMapViewDelegate, UIGe
         
         let layer = MGLFillStyleLayer(identifier: "state-layer", source: source)
         layer.sourceLayerIdentifier = "stateData_2-dx853g"
-        let stops = [0: MGLStyleValue<UIColor>(rawValue: .yellow),
-                     100: MGLStyleValue<UIColor>(rawValue: .red),
-                     1200: MGLStyleValue<UIColor>(rawValue: .blue)]
+        let stops = [
+            0: MGLStyleValue(rawValue: UIColor(red:0.94, green:0.93, blue:0.96, alpha:1.0)),
+            600: MGLStyleValue(rawValue: UIColor(red:0.62, green:0.60, blue:0.78, alpha:1.0)),
+            1200: MGLStyleValue(rawValue: UIColor(red:0.33, green:0.15, blue:0.56, alpha:1.0))]
         
-        layer.fillColor = MGLStyleValue(interpolationMode: .exponential, sourceStops: stops, attributeName: "density", options: [.defaultValue : MGLStyleValue<UIColor>(rawValue: .white)])
+        layer.fillColor = MGLStyleValue(interpolationMode: .exponential, sourceStops: stops, attributeName: "density", options: [.defaultValue : MGLStyleValue(rawValue: .white)])
         let symbolLayer = style.layer(withIdentifier: "place-city-sm")
         style.insertLayer(layer, below: symbolLayer!)
     }

--- a/Examples/Swift/DDSLayerSelectionExample.swift
+++ b/Examples/Swift/DDSLayerSelectionExample.swift
@@ -24,7 +24,7 @@ class DDSLayerSelectionExample_Swift: UIViewController, MGLMapViewDelegate, UIGe
     
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
         
-    // Load a tileset containing U.S. states and their population density. For more information about working with tilesets, see: https://www.mapbox.com/help/studio-manual-tilesets/
+        // Load a tileset containing U.S. states and their population density. For more information about working with tilesets, see: https://www.mapbox.com/help/studio-manual-tilesets/
         let url = URL(string: "mapbox://examples.69ytlgls")!
         let source = MGLVectorSource(identifier: "state-source", configurationURL: url)
         style.addSource(source)


### PR DESCRIPTION
![stateselection2](https://cloud.githubusercontent.com/assets/12474734/24225059/b4401970-0f1b-11e7-9aa4-3a7bf83bbd3e.gif)

We can possibly replace [select feature](https://www.mapbox.com/ios-sdk/examples/select-feature/) with this, since the feature selection example has a tile boundaries issue.

<img src="https://cloud.githubusercontent.com/assets/12474734/24176948/902a9b92-0e5c-11e7-80c1-0ba3022503d4.gif" width="200">

- [X] Add Swift Example
- [x] Add Objective-C Example
- [x] Add comments
~- [x] Fix the flicker where you can see the previous state (did a different deselection approach):~
- [x] Never mind, flicker is still there.
- [x] colors

There's still a slight lag when you select one state, then deselect all states, then select another.
![flickerondevice](https://cloud.githubusercontent.com/assets/12474734/24218146/7332e442-0eff-11e7-8a69-afac33cc204c.gif)