### PR TITLE
Set tint color to match map style

### DIFF
--- a/Examples/ObjectiveC/ClusteringExample.m
+++ b/Examples/ObjectiveC/ClusteringExample.m
@@ -18,6 +18,7 @@ NSString *const MBXExampleClustering = @"ClusteringExample";
 
     self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle lightStyleURLWithVersion:9]];
     self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.mapView.tintColor = [UIColor darkGrayColor];
     self.mapView.delegate = self;
     [self.view addSubview:self.mapView];
 

--- a/Examples/ObjectiveC/DDSCircleLayerExample.m
+++ b/Examples/ObjectiveC/DDSCircleLayerExample.m
@@ -19,6 +19,7 @@ NSString *const MBXExampleDDSCircleLayer = @"DDSCircleLayerExample";
         styleURL:[MGLStyle lightStyleURLWithVersion:9]];
     
     self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.mapView.tintColor = [UIColor darkGrayColor];
     
     // Set the map’s center coordinate and zoom level.
     self.mapView.centerCoordinate = CLLocationCoordinate2DMake(38.897,-77.039);

--- a/Examples/ObjectiveC/ShapeCollectionFeatureExample.m
+++ b/Examples/ObjectiveC/ShapeCollectionFeatureExample.m
@@ -14,6 +14,7 @@ NSString *const MBXExampleShapeCollectionFeature = @"ShapeCollectionFeatureExamp
     
     self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle lightStyleURLWithVersion:9]];
     self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    self.mapView.tintColor = [UIColor darkGrayColor];
     
     [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(38.897435, -77.039679) zoomLevel:12 animated:NO];
     self.mapView.delegate = self;

--- a/Examples/Swift/ClusteringExample.swift
+++ b/Examples/Swift/ClusteringExample.swift
@@ -13,6 +13,7 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
 
         mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.lightStyleURL(withVersion: 9))
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        mapView.tintColor = .darkGray
         mapView.delegate = self
         view.addSubview(mapView)
 

--- a/Examples/Swift/DDSCircleLayerExample.swift
+++ b/Examples/Swift/DDSCircleLayerExample.swift
@@ -13,6 +13,7 @@ class DDSCircleLayerExample_Swift: UIViewController, MGLMapViewDelegate {
         mapView = MGLMapView(frame: view.bounds)
         mapView.styleURL = MGLStyle.lightStyleURL(withVersion: 9)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        mapView.tintColor = .darkGray
         
         // Set the map’s center coordinate and zoom level.
         mapView.setCenter(CLLocationCoordinate2D(latitude: 38.897, longitude: -77.039), animated: false)

--- a/Examples/Swift/ShapeCollectionFeatureExample.swift
+++ b/Examples/Swift/ShapeCollectionFeatureExample.swift
@@ -12,6 +12,7 @@ class ShapeCollectionFeatureExample_Swift: UIViewController, MGLMapViewDelegate 
         mapView = MGLMapView(frame: view.bounds)
         mapView.styleURL = MGLStyle.lightStyleURL(withVersion: 9)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        mapView.tintColor = .darkGray
         
         mapView.setCenter(CLLocationCoordinate2D(latitude:38.897435, longitude: -77.039679), zoomLevel: 12, animated: false)
         


### PR DESCRIPTION
Updates some recent examples’ tint colors to match their map styles. The main (and only) difference is that this colors the ℹ️ icon.

![simulator screen shot mar 21 2017 8 47 07 pm](https://cloud.githubusercontent.com/assets/1198851/24177252/9d71e236-0e77-11e7-89a3-f40ca5ef4c71.png)

/cc @captainbarbosa