### PR TITLE
Update to v3.5.1 and Xcode 8.3

### DIFF
--- a/Examples.xcodeproj/project.pbxproj
+++ b/Examples.xcodeproj/project.pbxproj
@@ -1133,7 +1133,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0A4917D6B62E749D739044A4 /* Pods-ExamplesUITests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = YES;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = ExamplesUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1147,7 +1146,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E0520BEE090DE0364897BAF3 /* Pods-ExamplesUITests.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = YES;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = ExamplesUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/Examples/ObjectiveC/DDSLayerSelectionExample.m
+++ b/Examples/ObjectiveC/DDSLayerSelectionExample.m
@@ -80,7 +80,7 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
 
 - (void)changeOpacityBasedOn:(NSString*)name {
     
-    MGLFillStyleLayer *layer = [self.mapView.style layerWithIdentifier:@"state-layer"];
+    MGLFillStyleLayer *layer = (MGLFillStyleLayer *)[self.mapView.style layerWithIdentifier:@"state-layer"];
     
     // Check if a state was selected, then change the opacity of the states that were not selected.
     if (name.length > 0) {
@@ -89,7 +89,6 @@ NSString const *MBXExampleDDSLayerSelection = @"DDSLayerSelectionExample";
                 attributeName:@"name"
                 options:@{MGLStyleFunctionOptionDefaultValue: [MGLStyleValue valueWithRawValue:@0]}];
     } else {
-        
         // Reset the opacity for all states if the user did not tap on a state.
         layer.fillOpacity = [MGLStyleValue valueWithRawValue:@1];
     }

--- a/Examples/Swift/CustomCalloutViewExample.swift
+++ b/Examples/Swift/CustomCalloutViewExample.swift
@@ -11,30 +11,30 @@ class CustomCalloutViewExample_Swift: UIViewController, MGLMapViewDelegate {
         mapView.tintColor = .darkGray
         view.addSubview(mapView)
         
-        // Set the map view‘s delegate property
+        // Set the map view‘s delegate property.
         mapView.delegate = self
         
-        // Initialize and add the marker annotation
+        // Initialize and add the marker annotation.
         let marker = MGLPointAnnotation()
         marker.coordinate = CLLocationCoordinate2D(latitude: 0, longitude: 0)
         marker.title = "Hello world!"
         
-        // This custom callout example does not implement subtitles
+        // This custom callout example does not implement subtitles.
         //marker.subtitle = "Welcome to my marker"
         
-        // Add marker to the map
+        // Add marker to the map.
         mapView.addAnnotation(marker)
     }
     
     func mapView(_ mapView: MGLMapView, annotationCanShowCallout annotation: MGLAnnotation) -> Bool {
-        // Always allow callouts to popup when annotations are tapped
+        // Always allow callouts to popup when annotations are tapped.
         return true
     }
-    
-    func mapView(_ mapView: MGLMapView, calloutViewFor annotation: MGLAnnotation) -> UIView? {
-        // Only show callouts for `Hello world!` annotation
+
+    func mapView(_ mapView: MGLMapView, calloutViewFor annotation: MGLAnnotation) -> MGLCalloutView? {
+        // Only show callouts for `Hello world!` annotation.
         if annotation.responds(to: #selector(getter: MGLAnnotation.title)) && annotation.title! == "Hello world!" {
-            // Instantiate and return our custom callout view
+            // Instantiate and return our custom callout view.
             return CustomCalloutView(representedObject: annotation)
         }
         
@@ -42,10 +42,10 @@ class CustomCalloutViewExample_Swift: UIViewController, MGLMapViewDelegate {
     }
     
     func mapView(_ mapView: MGLMapView, tapOnCalloutFor annotation: MGLAnnotation) {
-        // Optionally handle taps on the callout
+        // Optionally handle taps on the callout.
         print("Tapped the callout for: \(annotation)")
         
-        // Hide the callout
+        // Hide the callout.
         mapView.deselectAnnotation(annotation, animated: true)
     }
 }

--- a/Examples/Swift/OfflinePackExample.swift
+++ b/Examples/Swift/OfflinePackExample.swift
@@ -48,7 +48,7 @@ class OfflinePackExample_Swift: UIViewController, MGLMapViewDelegate {
         MGLOfflineStorage.shared().addPack(for: region, withContext: context) { (pack, error) in
             guard error == nil else {
                 // The pack couldn’t be created for some reason.
-                print("Error: \(error?.localizedDescription)")
+                print("Error: \(error?.localizedDescription ?? "unknown error")")
                 return
             }
             
@@ -86,10 +86,10 @@ class OfflinePackExample_Swift: UIViewController, MGLMapViewDelegate {
             // If this pack has finished, print its size and resource count.
             if completedResources == expectedResources {
                 let byteCount = ByteCountFormatter.string(fromByteCount: Int64(pack.progress.countOfBytesCompleted), countStyle: ByteCountFormatter.CountStyle.memory)
-                print("Offline pack “\(userInfo["name"])” completed: \(byteCount), \(completedResources) resources")
+                print("Offline pack “\(userInfo["name"] ?? "unknown")” completed: \(byteCount), \(completedResources) resources")
             } else {
                 // Otherwise, print download/verification progress.
-                print("Offline pack “\(userInfo["name"])” has \(completedResources) of \(expectedResources) resources — \(progressPercentage * 100)%.")
+                print("Offline pack “\(userInfo["name"] ?? "unknown")” has \(completedResources) of \(expectedResources) resources — \(progressPercentage * 100)%.")
             }
         }
     }
@@ -98,7 +98,7 @@ class OfflinePackExample_Swift: UIViewController, MGLMapViewDelegate {
         if let pack = notification.object as? MGLOfflinePack,
             let userInfo = NSKeyedUnarchiver.unarchiveObject(with: pack.context) as? [String: String],
             let error = notification.userInfo?[MGLOfflinePackUserInfoKey.error] as? NSError {
-            print("Offline pack “\(userInfo["name"])” received error: \(error.localizedFailureReason)")
+            print("Offline pack “\(userInfo["name"] ?? "unknown")” received error: \(error.localizedFailureReason ?? "unknown error")")
         }
     }
     
@@ -106,7 +106,7 @@ class OfflinePackExample_Swift: UIViewController, MGLMapViewDelegate {
         if let pack = notification.object as? MGLOfflinePack,
             let userInfo = NSKeyedUnarchiver.unarchiveObject(with: pack.context) as? [String: String],
             let maximumCount = (notification.userInfo?[MGLOfflinePackUserInfoKey.maximumCount] as AnyObject).uint64Value {
-            print("Offline pack “\(userInfo["name"])” reached limit of \(maximumCount) tiles.")
+            print("Offline pack “\(userInfo["name"] ?? "unknown")” reached limit of \(maximumCount) tiles.")
         }
     }
     

--- a/Examples/Swift/RuntimeAddLineExample.swift
+++ b/Examples/Swift/RuntimeAddLineExample.swift
@@ -56,7 +56,7 @@ class RuntimeAddLineExample_Swift: UIViewController, MGLMapViewDelegate {
         layer.lineWidth = MGLStyleValue(interpolationMode: .exponential,
             cameraStops: [14: MGLStyleValue<NSNumber>(rawValue: 2),
                           18: MGLStyleValue<NSNumber>(rawValue: 20)],
-            options: [.defaultValue : MGLStyleConstantValue<NSNumber>(rawValue: 1.5)])
+            options: [.defaultValue : MGLConstantStyleValue<NSNumber>(rawValue: 1.5)])
 
         // We can also add a second layer that will draw a stroke around the original line.
         let casingLayer = MGLLineStyleLayer(identifier: "polyline-case", source: source)
@@ -71,7 +71,7 @@ class RuntimeAddLineExample_Swift: UIViewController, MGLMapViewDelegate {
         casingLayer.lineWidth = MGLStyleValue(interpolationMode: .exponential,
             cameraStops: [14: MGLStyleValue(rawValue: 1),
                           18: MGLStyleValue(rawValue: 4)],
-            options: [.defaultValue : MGLStyleConstantValue<NSNumber>(rawValue: 1.5)])
+            options: [.defaultValue : MGLConstantStyleValue<NSNumber>(rawValue: 1.5)])
 
         // Just for fun, let’s add another copy of the line with a dash pattern.
         let dashedLayer = MGLLineStyleLayer(identifier: "polyline-dash", source: source)

--- a/Examples/Swift/RuntimeAnimateLineExample.swift
+++ b/Examples/Swift/RuntimeAnimateLineExample.swift
@@ -44,9 +44,9 @@ class RuntimeAnimateLineExample_Swift: UIViewController, MGLMapViewDelegate {
         layer.lineCap = MGLStyleValue(rawValue: NSValue(mglLineCap: .round))
         layer.lineColor = MGLStyleValue(rawValue: UIColor.red)
         layer.lineWidth = MGLStyleFunction(interpolationMode: .exponential,
-            cameraStops: [14: MGLStyleConstantValue<NSNumber>(rawValue: 5),
-                          18: MGLStyleConstantValue<NSNumber>(rawValue: 20)],
-            options: [.defaultValue : MGLStyleConstantValue<NSNumber>(rawValue: 1.5)])
+            cameraStops: [14: MGLConstantStyleValue<NSNumber>(rawValue: 5),
+                          18: MGLConstantStyleValue<NSNumber>(rawValue: 20)],
+            options: [.defaultValue : MGLConstantStyleValue<NSNumber>(rawValue: 1.5)])
         style.addLayer(layer)
     }
 

--- a/ExamplesUITests/ExamplesUITests.m
+++ b/ExamplesUITests/ExamplesUITests.m
@@ -16,9 +16,7 @@
 
 - (void)setUp {
     [super setUp];
-    
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-    
+
     // In UI tests it is usually best to stop immediately when a failure occurs.
     self.continueAfterFailure = NO;
 
@@ -29,7 +27,6 @@
 }
 
 - (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
     [super tearDown];
 }
 
@@ -39,37 +36,10 @@
     for (int i = 0; i < app.tables.cells.count; i++) {
         [app.tables.cells.allElementsBoundByIndex[i] tap];
 
-        XCUIElement *map = app.otherElements[@"Map"];
-        [self waitForElementToBeHittable:map];
-
-        // Just too unreliable.
-//        [map doubleTap];
-//        [map twoFingerTap];
-
-        // Rotation flaps when the gesture doesn't fire reliably
-//        [map rotate:M_1_PI withVelocity:1];
-//
-//        XCUIElement *compass = map.images[@"Compass"];
-//        [self waitForElementToBeHittable:compass];
-//        [compass tap];
+        // XCTest waits for the app to idle before continuing.
 
         [app.navigationBars.buttons[@"Back"] tap];
     }
-
-}
-
-- (void)waitForElementToBeHittable:(XCUIElement *)element {
-    NSPredicate *hittablePredicate = [NSPredicate predicateWithFormat:@"hittable == true"];
-    [self expectationForPredicate:hittablePredicate evaluatedWithObject:element handler:nil];
-
-    [self waitForExpectationsWithTimeout:1 handler:^(NSError * _Nullable error) {
-        if (error != nil) {
-            [self recordFailureWithDescription:[NSString stringWithFormat:@"%@ failed to be hittable after 1 second.", element]
-                                        inFile:@__FILE__
-                                        atLine:__LINE__
-                                      expected:NO];
-        }
-    }];
 }
 
 @end

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ use_frameworks!
 
 target 'Examples' do
   # Pods for Examples
-  pod 'Mapbox-iOS-SDK-symbols', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.5.0/platform/ios/Mapbox-iOS-SDK-symbols.podspec'
+  pod 'Mapbox-iOS-SDK-symbols', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.5.1/platform/ios/Mapbox-iOS-SDK-symbols.podspec'
 
 end
 
@@ -14,5 +14,3 @@ end
 target 'ExamplesUITests' do
     # Pods for testing
 end
-
-ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - Mapbox-iOS-SDK-symbols (3.5.0-symbols)
+  - Mapbox-iOS-SDK-symbols (3.5.1-symbols)
 
 DEPENDENCIES:
-  - Mapbox-iOS-SDK-symbols (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.5.0/platform/ios/Mapbox-iOS-SDK-symbols.podspec`)
+  - Mapbox-iOS-SDK-symbols (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.5.1/platform/ios/Mapbox-iOS-SDK-symbols.podspec`)
 
 EXTERNAL SOURCES:
   Mapbox-iOS-SDK-symbols:
-    :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.5.0/platform/ios/Mapbox-iOS-SDK-symbols.podspec
+    :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.5.1/platform/ios/Mapbox-iOS-SDK-symbols.podspec
 
 SPEC CHECKSUMS:
-  Mapbox-iOS-SDK-symbols: de98980e19f34183eef3c1cc3f4294f0e4c3c217
+  Mapbox-iOS-SDK-symbols: 9bcd5fdb91b02f7f9acfa3447383aa01c9ff5178
 
-PODFILE CHECKSUM: f0a38bf36f0562eddea097592a97657f8dee496e
+PODFILE CHECKSUM: 789927258b0890e86e7cf239455c0f6ab83bf9ea
 
 COCOAPODS: 1.2.0


### PR DESCRIPTION
- Update to [Mapbox iOS SDK v3.5.1](https://github.com/mapbox/mapbox-gl-native/releases/tag/ios-v3.5.1).
- Manually rename `MGLStyleConstantValue ` to `MGLConstantStyleValue`, as the compatibility alias crashes Swift. (https://github.com/mapbox/mapbox-gl-native/issues/8567)
- Take advantage of improved `MGLCalloutView` bridging in `mapView:calloutViewFor annotation:` delegate method. (https://github.com/mapbox/mapbox-gl-native/pull/8541)
- Silence a technically correct but harmless incompatible types warning. (https://github.com/mapbox/ios-sdk-examples/commit/4b7dc5d6b1e4c7f2aea86299d31b725391d151ea)
- Miscellaneous fixes for Xcode 8.3 and Swift 3.1 changes.
- Reenable CocoaPods stats. 💆

/cc @1ec5 @boundsj