### PR TITLE
Removed withVersion:9

### DIFF
--- a/Examples/ObjectiveC/AnnotationViewExample.m
+++ b/Examples/ObjectiveC/AnnotationViewExample.m
@@ -46,7 +46,7 @@ NSString *const MBXExampleAnnotationView = @"AnnotationViewExample";
 
     MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
     mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    mapView.styleURL = [MGLStyle darkStyleURLWithVersion:9];
+    mapView.styleURL = [MGLStyle darkStyleURL];
     mapView.tintColor = [UIColor lightGrayColor];
     mapView.centerCoordinate = CLLocationCoordinate2DMake(0, 66);
     mapView.zoomLevel = 2;

--- a/Examples/ObjectiveC/AnnotationViewMultipleExample.m
+++ b/Examples/ObjectiveC/AnnotationViewMultipleExample.m
@@ -22,7 +22,7 @@ NSString *const MBXExampleAnnotationViewMultiple = @"AnnotationViewMultipleExamp
     
     // Create a new map view using the Mapbox Light style.
     MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds
-        styleURL:[MGLStyle lightStyleURLWithVersion:9]];
+        styleURL:[MGLStyle lightStyleURL]];
     
     mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     

--- a/Examples/ObjectiveC/BlockingGesturesDelegateExample.m
+++ b/Examples/ObjectiveC/BlockingGesturesDelegateExample.m
@@ -15,7 +15,7 @@ NSString *const MBXExampleBlockingGesturesDelegate = @"BlockingGesturesDelegateE
     MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
     mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     mapView.delegate = self;
-    mapView.styleURL = [MGLStyle outdoorsStyleURLWithVersion:9];
+    mapView.styleURL = [MGLStyle outdoorsStyleURL];
     
     // Denver, Colorado
     CLLocationCoordinate2D center = CLLocationCoordinate2DMake(39.748947, -104.995882);

--- a/Examples/ObjectiveC/CameraAnimationExample.m
+++ b/Examples/ObjectiveC/CameraAnimationExample.m
@@ -15,7 +15,7 @@ NSString *const MBXExampleCameraAnimation = @"CameraAnimationExample";
     mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     mapView.delegate = self;
 
-    mapView.styleURL = [MGLStyle outdoorsStyleURLWithVersion:9];
+    mapView.styleURL = [MGLStyle outdoorsStyleURL];
 
     // Mauna Kea, Hawaii
     CLLocationCoordinate2D center = CLLocationCoordinate2DMake(19.820689, -155.468038);

--- a/Examples/ObjectiveC/ClusteringExample.m
+++ b/Examples/ObjectiveC/ClusteringExample.m
@@ -16,7 +16,7 @@ NSString *const MBXExampleClustering = @"ClusteringExample";
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-    self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle lightStyleURLWithVersion:9]];
+    self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle lightStyleURL]];
     self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.mapView.tintColor = [UIColor darkGrayColor];
     self.mapView.delegate = self;

--- a/Examples/ObjectiveC/CustomAnnotationModelExample.m
+++ b/Examples/ObjectiveC/CustomAnnotationModelExample.m
@@ -14,7 +14,7 @@ NSString *const MBXExampleCustomAnnotationModel = @"CustomAnnotationModelExample
 
     MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
     mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    mapView.styleURL = [MGLStyle lightStyleURLWithVersion:9];
+    mapView.styleURL = [MGLStyle lightStyleURL];
     mapView.tintColor = [UIColor darkGrayColor];
     mapView.zoomLevel = 1;
     mapView.delegate = self;

--- a/Examples/ObjectiveC/CustomCalloutViewExample.m
+++ b/Examples/ObjectiveC/CustomCalloutViewExample.m
@@ -12,7 +12,7 @@ NSString *const MBXExampleCustomCalloutView = @"CustomCalloutViewExample";
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-    MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle lightStyleURLWithVersion:9]];
+    MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle lightStyleURL]];
     mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     mapView.tintColor = [UIColor darkGrayColor];
     [self.view addSubview:mapView];

--- a/Examples/ObjectiveC/DDSCircleLayerExample.m
+++ b/Examples/ObjectiveC/DDSCircleLayerExample.m
@@ -16,7 +16,7 @@ NSString *const MBXExampleDDSCircleLayer = @"DDSCircleLayerExample";
 
     // Create a new map view using the Mapbox Light style.
     self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds
-        styleURL:[MGLStyle lightStyleURLWithVersion:9]];
+        styleURL:[MGLStyle lightStyleURL]];
     
     self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.mapView.tintColor = [UIColor darkGrayColor];

--- a/Examples/ObjectiveC/DefaultStylesExample.m
+++ b/Examples/ObjectiveC/DefaultStylesExample.m
@@ -9,7 +9,7 @@ NSString *const MBXExampleDefaultStyles = @"DefaultStylesExample";
     [super viewDidLoad];
 
     MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds
-                                                   styleURL:[MGLStyle outdoorsStyleURLWithVersion:9]];
+                                                   styleURL:[MGLStyle outdoorsStyleURL]];
 
     // Tint the ℹ️ button and the user location annotation.
     mapView.tintColor = [UIColor darkGrayColor];

--- a/Examples/ObjectiveC/DraggableAnnotationViewExample.m
+++ b/Examples/ObjectiveC/DraggableAnnotationViewExample.m
@@ -87,7 +87,7 @@ NSString *const MBXExampleDraggableAnnotationView = @"DraggableAnnotationViewExa
 
     MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
     mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    mapView.styleURL = [MGLStyle lightStyleURLWithVersion:9];
+    mapView.styleURL = [MGLStyle lightStyleURL];
     mapView.tintColor = [UIColor darkGrayColor];
     mapView.zoomLevel = 1;
     mapView.delegate = self;

--- a/Examples/ObjectiveC/DrawingACustomMarkerExample.m
+++ b/Examples/ObjectiveC/DrawingACustomMarkerExample.m
@@ -11,7 +11,7 @@ NSString *const MBXExampleDrawingACustomMarker = @"DrawingACustomMarkerExample";
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    NSURL *styleURL = [MGLStyle lightStyleURLWithVersion:9];
+    NSURL *styleURL = [MGLStyle lightStyleURL];
     MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:styleURL];
     mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     mapView.tintColor = [UIColor darkGrayColor];

--- a/Examples/ObjectiveC/ExtrusionsExample.m
+++ b/Examples/ObjectiveC/ExtrusionsExample.m
@@ -21,7 +21,7 @@ NSString *const MBXExample3DExtrusions = @"ExtrusionsExample";
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle lightStyleURLWithVersion:9]];
+    MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle lightStyleURL]];
     
     // Center the map on the Colosseum in Rome, Italy.
     

--- a/Examples/ObjectiveC/ExtrusionsExample.m
+++ b/Examples/ObjectiveC/ExtrusionsExample.m
@@ -21,6 +21,7 @@ NSString *const MBXExample3DExtrusions = @"ExtrusionsExample";
 - (void)viewDidLoad {
     [super viewDidLoad];
     
+    // Set the map style to Mapbox Light Style version 9. The map's source will be queried later in this example.
     MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle lightStyleURLWithVersion:9]];
     
     // Center the map view on the Colosseum in Rome, Italy and set the camera's pitch and distance.

--- a/Examples/ObjectiveC/ExtrusionsExample.m
+++ b/Examples/ObjectiveC/ExtrusionsExample.m
@@ -21,9 +21,7 @@ NSString *const MBXExample3DExtrusions = @"ExtrusionsExample";
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle lightStyleURL]];
-    
-    // Center the map on the Colosseum in Rome, Italy.
+    MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle lightStyleURLWithVersion:9]];
     
     // Center the map view on the Colosseum in Rome, Italy and set the camera's pitch and distance.
     mapView.camera = [MGLMapCamera cameraLookingAtCenterCoordinate:CLLocationCoordinate2DMake(41.8902, 12.4922) fromDistance:600 pitch:60 heading:0];

--- a/Examples/ObjectiveC/OfflinePackExample.m
+++ b/Examples/ObjectiveC/OfflinePackExample.m
@@ -13,7 +13,7 @@ NSString *const MBXExampleOfflinePack = @"OfflinePackExample";
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-    self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle darkStyleURLWithVersion:9]];
+    self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle darkStyleURL]];
     self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.mapView.tintColor = [UIColor lightGrayColor];
     self.mapView.delegate = self;

--- a/Examples/ObjectiveC/RuntimeCircleStylesExample.m
+++ b/Examples/ObjectiveC/RuntimeCircleStylesExample.m
@@ -15,7 +15,7 @@ NSString *const MBXExampleRuntimeCircleStyles = @"RuntimeCircleStylesExample";
     [super viewDidLoad];
 
     self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
-    [self.mapView setStyleURL:[MGLStyle lightStyleURLWithVersion:9]];
+    [self.mapView setStyleURL:[MGLStyle lightStyleURL]];
     self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.mapView.tintColor = [UIColor darkGrayColor];
 

--- a/Examples/ObjectiveC/SatelliteStyleExample.m
+++ b/Examples/ObjectiveC/SatelliteStyleExample.m
@@ -9,7 +9,7 @@ NSString *const MBXExampleSatelliteStyle = @"SatelliteStyleExample";
     [super viewDidLoad];
     
     // A hybrid style with unobtrusive labels is also available via +satelliteStreetsStyleURLWithVersion:.
-    NSURL *styleURL = [MGLStyle satelliteStyleURLWithVersion:9];
+    NSURL *styleURL = [MGLStyle satelliteStyleURL];
     MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:styleURL];
 
     // Tint the ℹ️ button.

--- a/Examples/ObjectiveC/ShapeCollectionFeatureExample.m
+++ b/Examples/ObjectiveC/ShapeCollectionFeatureExample.m
@@ -12,7 +12,7 @@ NSString *const MBXExampleShapeCollectionFeature = @"ShapeCollectionFeatureExamp
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle lightStyleURLWithVersion:9]];
+    self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle lightStyleURL]];
     self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.mapView.tintColor = [UIColor darkGrayColor];
     

--- a/Examples/ObjectiveC/UserTrackingModesExample.m
+++ b/Examples/ObjectiveC/UserTrackingModesExample.m
@@ -8,7 +8,7 @@ NSString *const MBXExampleUserTrackingModes = @"UserTrackingModesExample";
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-    MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle darkStyleURLWithVersion:9]];
+    MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle darkStyleURL]];
     mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
     mapView.userTrackingMode = MGLUserTrackingModeFollowWithHeading;

--- a/Examples/Swift/AnnotationViewExample.swift
+++ b/Examples/Swift/AnnotationViewExample.swift
@@ -9,7 +9,7 @@ class AnnotationViewExample_Swift: UIViewController, MGLMapViewDelegate {
     
         let mapView = MGLMapView(frame: view.bounds)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        mapView.styleURL = MGLStyle.darkStyleURL(withVersion: 9)
+        mapView.styleURL = MGLStyle.darkStyleURL()
         mapView.tintColor = .lightGray
         mapView.centerCoordinate = CLLocationCoordinate2D(latitude: 0, longitude: 66)
         mapView.zoomLevel = 2

--- a/Examples/Swift/AnnotationViewMultipleExample.swift
+++ b/Examples/Swift/AnnotationViewMultipleExample.swift
@@ -13,7 +13,7 @@ class AnnotationViewMultipleExample_Swift: UIViewController, MGLMapViewDelegate 
         super.viewDidLoad()
         
         // Create a new map view using the Mapbox Light style.
-        let mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.lightStyleURL(withVersion: 9))
+        let mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.lightStyleURL())
         
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         

--- a/Examples/Swift/CameraAnimationExample.swift
+++ b/Examples/Swift/CameraAnimationExample.swift
@@ -10,7 +10,7 @@ class CameraAnimationExample_Swift: UIViewController, MGLMapViewDelegate {
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.delegate = self
         
-        mapView.styleURL = MGLStyle.outdoorsStyleURL(withVersion: 9);
+        mapView.styleURL = MGLStyle.outdoorsStyleURL();
         
         // Mauna Kea, Hawaii
         let center = CLLocationCoordinate2D(latitude: 19.820689, longitude: -155.468038)

--- a/Examples/Swift/ClusteringExample.swift
+++ b/Examples/Swift/ClusteringExample.swift
@@ -11,7 +11,7 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.lightStyleURL(withVersion: 9))
+        mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.lightStyleURL())
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.tintColor = .darkGray
         mapView.delegate = self

--- a/Examples/Swift/CustomAnnotationModelExample.swift
+++ b/Examples/Swift/CustomAnnotationModelExample.swift
@@ -8,7 +8,7 @@ class CustomAnnotationModelExample_Swift: UIViewController, MGLMapViewDelegate {
         
         let mapView = MGLMapView(frame: view.bounds)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        mapView.styleURL = MGLStyle.lightStyleURL(withVersion: 9)
+        mapView.styleURL = MGLStyle.lightStyleURL()
         mapView.tintColor = .darkGray
         mapView.zoomLevel = 1
         mapView.delegate = self

--- a/Examples/Swift/CustomCalloutViewExample.swift
+++ b/Examples/Swift/CustomCalloutViewExample.swift
@@ -6,7 +6,7 @@ class CustomCalloutViewExample_Swift: UIViewController, MGLMapViewDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.lightStyleURL(withVersion: 9))
+        let mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.lightStyleURL())
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.tintColor = .darkGray
         view.addSubview(mapView)

--- a/Examples/Swift/DDSCircleLayerExample.swift
+++ b/Examples/Swift/DDSCircleLayerExample.swift
@@ -11,7 +11,7 @@ class DDSCircleLayerExample_Swift: UIViewController, MGLMapViewDelegate {
         
         // Create a new map view using the Mapbox Light style.
         mapView = MGLMapView(frame: view.bounds)
-        mapView.styleURL = MGLStyle.lightStyleURL(withVersion: 9)
+        mapView.styleURL = MGLStyle.lightStyleURL()
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.tintColor = .darkGray
         

--- a/Examples/Swift/DefaultStylesExample.swift
+++ b/Examples/Swift/DefaultStylesExample.swift
@@ -7,7 +7,7 @@ class DefaultStylesExample_Swift: UIViewController {
         super.viewDidLoad()
         
         let mapView = MGLMapView(frame: view.bounds,
-                                 styleURL: MGLStyle.outdoorsStyleURL(withVersion: 9))
+                                 styleURL: MGLStyle.outdoorsStyleURL())
         
         // Tint the ℹ️ button and the user location annotation.
         mapView.tintColor = .darkGray

--- a/Examples/Swift/DraggableAnnotationViewExample.swift
+++ b/Examples/Swift/DraggableAnnotationViewExample.swift
@@ -9,7 +9,7 @@ class DraggableAnnotationViewExample_Swift: UIViewController, MGLMapViewDelegate
         
         let mapView = MGLMapView(frame: view.bounds)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        mapView.styleURL = MGLStyle.lightStyleURL(withVersion: 9)
+        mapView.styleURL = MGLStyle.lightStyleURL()
         mapView.tintColor = .darkGray
         mapView.zoomLevel = 1
         mapView.delegate = self

--- a/Examples/Swift/DrawingACustomMarkerExample.swift
+++ b/Examples/Swift/DrawingACustomMarkerExample.swift
@@ -6,7 +6,7 @@ class DrawingACustomMarkerExample_Swift: UIViewController, MGLMapViewDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.lightStyleURL(withVersion: 9))
+        let mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.lightStyleURL())
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.tintColor = .darkGray
         

--- a/Examples/Swift/ExtrusionsExample.swift
+++ b/Examples/Swift/ExtrusionsExample.swift
@@ -15,6 +15,7 @@ class ExtrusionsExample: UIViewController, MGLMapViewDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        // Set the map style to Mapbox Light Style version 9. The map's source will be queried later in this example.
         let mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.lightStyleURL(withVersion: 9))
         
         // Center the map view on the Colosseum in Rome, Italy and set the camera's pitch and distance.

--- a/Examples/Swift/ExtrusionsExample.swift
+++ b/Examples/Swift/ExtrusionsExample.swift
@@ -15,7 +15,7 @@ class ExtrusionsExample: UIViewController, MGLMapViewDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.lightStyleURL(withVersion: 9))
+        let mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.lightStyleURL())
         
     // Center the map view on the Colosseum in Rome, Italy and set the camera's pitch and distance.
         mapView.camera = MGLMapCamera(lookingAtCenter: CLLocationCoordinate2D(latitude: 41.8902, longitude: 12.4922), fromDistance: 600, pitch: 60, heading: 0)

--- a/Examples/Swift/ExtrusionsExample.swift
+++ b/Examples/Swift/ExtrusionsExample.swift
@@ -15,9 +15,9 @@ class ExtrusionsExample: UIViewController, MGLMapViewDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.lightStyleURL())
+        let mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.lightStyleURL(withVersion: 9))
         
-    // Center the map view on the Colosseum in Rome, Italy and set the camera's pitch and distance.
+        // Center the map view on the Colosseum in Rome, Italy and set the camera's pitch and distance.
         mapView.camera = MGLMapCamera(lookingAtCenter: CLLocationCoordinate2D(latitude: 41.8902, longitude: 12.4922), fromDistance: 600, pitch: 60, heading: 0)
         mapView.delegate = self
         
@@ -26,7 +26,6 @@ class ExtrusionsExample: UIViewController, MGLMapViewDelegate {
     
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
         
-        let array = [1, 2, 4, 6]
         // Access the Mapbox Streets source and use it to create a `MGLFillExtrusionStyleLayer`. The source identifier is `composite`. Use the `sources` property on a style to verify source identifiers.
         if let source = style.source(withIdentifier: "composite") {
             let layer = MGLFillExtrusionStyleLayer(identifier: "buildings", source: source)

--- a/Examples/Swift/OfflinePackExample.swift
+++ b/Examples/Swift/OfflinePackExample.swift
@@ -9,7 +9,7 @@ class OfflinePackExample_Swift: UIViewController, MGLMapViewDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.darkStyleURL(withVersion: 9))
+        mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.darkStyleURL())
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.tintColor = .gray
         mapView.delegate = self

--- a/Examples/Swift/RuntimeCircleStylesExample.swift
+++ b/Examples/Swift/RuntimeCircleStylesExample.swift
@@ -9,7 +9,7 @@ class RuntimeCircleStylesExample_Swift: UIViewController, MGLMapViewDelegate {
         super.viewDidLoad()
 
         mapView = MGLMapView(frame: view.bounds)
-        mapView.styleURL = MGLStyle.lightStyleURL(withVersion: 9)
+        mapView.styleURL = MGLStyle.lightStyleURL()
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.tintColor = .darkGray
 

--- a/Examples/Swift/RuntimeCircleStylesExample.swift
+++ b/Examples/Swift/RuntimeCircleStylesExample.swift
@@ -54,7 +54,6 @@ class RuntimeCircleStylesExample_Swift: UIViewController, MGLMapViewDelegate {
                               22: MGLStyleValue(rawValue: 180)],
                 options: [.defaultValue : 1.75])
             
-//            (interpolationBase: 1.75, stops: )
             layer.circleOpacity = MGLStyleValue(rawValue: 0.7)
 
             // Set the circle color to match the ethnicity.

--- a/Examples/Swift/SatelliteStyleExample.swift
+++ b/Examples/Swift/SatelliteStyleExample.swift
@@ -9,7 +9,7 @@ class SatelliteStyleExample_Swift: UIViewController {
         super.viewDidLoad()
         
         // A hybrid style with unobtrusive labels is also available via satelliteStreetsStyleURL(withVersion:).
-        mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.satelliteStyleURL(withVersion: 9))
+        mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.satelliteStyleURL())
         
         // Tint the ℹ️ button.
         mapView.attributionButton.tintColor = .white

--- a/Examples/Swift/ShapeCollectionFeatureExample.swift
+++ b/Examples/Swift/ShapeCollectionFeatureExample.swift
@@ -10,7 +10,7 @@ class ShapeCollectionFeatureExample_Swift: UIViewController, MGLMapViewDelegate 
         super.viewDidLoad()
         
         mapView = MGLMapView(frame: view.bounds)
-        mapView.styleURL = MGLStyle.lightStyleURL(withVersion: 9)
+        mapView.styleURL = MGLStyle.lightStyleURL()
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.tintColor = .darkGray
         

--- a/Examples/Swift/UserTrackingModesExample.swift
+++ b/Examples/Swift/UserTrackingModesExample.swift
@@ -9,7 +9,7 @@ class UserTrackingModesExample_Swift: UIViewController, MGLMapViewDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.darkStyleURL(withVersion: 9))
+        mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.darkStyleURL())
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.delegate = self
         


### PR DESCRIPTION
Removed `withVersion:` from the current examples since it is not necessary in v3.6.0.