### PR TITLE
Fix automated TestFlight/fastlane builds

### DIFF
--- a/Examples.xcodeproj/project.pbxproj
+++ b/Examples.xcodeproj/project.pbxproj
@@ -1108,6 +1108,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 0;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1133,6 +1134,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 0;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Examples/Info.plist
+++ b/Examples/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSLocationWhenInUseUsageDescription</key>

--- a/ExamplesTests/Info.plist
+++ b/ExamplesTests/Info.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>0</string>
 </dict>
 </plist>

--- a/ExamplesUITests/Info.plist
+++ b/ExamplesUITests/Info.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>0</string>
 </dict>
 </plist>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,7 +6,7 @@
 # Change the syntax highlighting to Ruby
 # All lines starting with a # are ignored when running `fastlane`
 
-fastlane_version "2.36.0"
+fastlane_version "2.43.0"
 opt_out_usage
 
 default_platform :ios
@@ -25,8 +25,8 @@ platform :ios do
   desc "Submit a new build to Apple TestFlight."
   lane :beta do
     increment_build_number(build_number: latest_testflight_build_number + 1)
-    gym(scheme: "Examples", clean: false, output_directory: "build/", include_bitcode: true)
-    pilot(skip_waiting_for_build_processing: true, ipa: "build/Examples.ipa")
+    gym(scheme: "Examples", include_bitcode: true)
+    pilot(skip_waiting_for_build_processing: true)
   end
 
   after_all do |lane|


### PR DESCRIPTION
Not sure why this only started failing now, but specify a dummy `CURRENT_PROJECT_VERSION` (build version).