### PR TITLE
Add resizing mask to Obj-C example

### DIFF
--- a/Examples/ObjectiveC/FillPatternExample.m
+++ b/Examples/ObjectiveC/FillPatternExample.m
@@ -14,11 +14,14 @@ NSString *const MBXExampleFillPattern = @"FillPatternExample";
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    // Set the map’s size, style, center coordinate, and zoom level.
     MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.frame styleURL:[MGLStyle darkStyleURLWithVersion:9]];
+    mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    
+    // Set the map’s size, style, center coordinate, and zoom level.
     [mapView setCenterCoordinate:CLLocationCoordinate2DMake(38.849534447, -77.039222717)
                        zoomLevel:8.5
                         animated:NO];
+    
     mapView.delegate = self;
     
     [self.view addSubview:mapView];


### PR DESCRIPTION
Fixes the fill pattern Objective-C example by adding an `autoresizingMask` to the map view.

**Before**
![image uploaded from ios 1](https://user-images.githubusercontent.com/10850812/27874857-2107ce12-617f-11e7-804c-c609de38eaf6.jpg)

**After** ✨ 
![simulator screen shot jul 5 2017 12 42 11 pm](https://user-images.githubusercontent.com/10850812/27874928-63c1da90-617f-11e7-9ac1-d77b49b5d204.png)

