### PR TITLE
Bump to Mapbox iOS SDK v3.6.2

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,8 +3,7 @@ use_frameworks!
 
 target 'Examples' do
   # Pods for Examples
-  pod 'Mapbox-iOS-SDK-symbols', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.6.1/platform/ios/Mapbox-iOS-SDK-symbols.podspec'
-
+  pod 'Mapbox-iOS-SDK-symbols', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.6.2/platform/ios/Mapbox-iOS-SDK-symbols.podspec'
 end
 
 target 'ExamplesTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - Mapbox-iOS-SDK-symbols (3.6.1-symbols)
+  - Mapbox-iOS-SDK-symbols (3.6.2-symbols)
 
 DEPENDENCIES:
-  - Mapbox-iOS-SDK-symbols (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.6.1/platform/ios/Mapbox-iOS-SDK-symbols.podspec`)
+  - Mapbox-iOS-SDK-symbols (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.6.2/platform/ios/Mapbox-iOS-SDK-symbols.podspec`)
 
 EXTERNAL SOURCES:
   Mapbox-iOS-SDK-symbols:
-    :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.6.1/platform/ios/Mapbox-iOS-SDK-symbols.podspec
+    :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.6.2/platform/ios/Mapbox-iOS-SDK-symbols.podspec
 
 SPEC CHECKSUMS:
-  Mapbox-iOS-SDK-symbols: 95ed159f9126736e279919ecf28d2ea6c40ea710
+  Mapbox-iOS-SDK-symbols: 531663a5e28e80175440638861468dc5ebc22262
 
-PODFILE CHECKSUM: 506c2d22b088dad61b80255a5b4d3b2ae0d68063
+PODFILE CHECKSUM: 9f2be7b081fead8993be6f92c82017b505a0d9e2
 
 COCOAPODS: 1.3.1


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gl-native/releases/tag/ios-v3.6.2