### PR TITLE
Bump to Mapbox iOS SDK v3.6.4

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ use_frameworks!
 
 def shared_pods
   #pod 'Mapbox-iOS-SDK', '~> 3.6.3'
-  pod 'Mapbox-iOS-SDK-symbols', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.6.3/platform/ios/Mapbox-iOS-SDK-symbols.podspec'
+  pod 'Mapbox-iOS-SDK-symbols', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.6.4/platform/ios/Mapbox-iOS-SDK-symbols.podspec'
 end
 
 target 'Examples' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - Mapbox-iOS-SDK-symbols (3.6.3-symbols)
+  - Mapbox-iOS-SDK-symbols (3.6.4-symbols)
 
 DEPENDENCIES:
-  - Mapbox-iOS-SDK-symbols (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.6.3/platform/ios/Mapbox-iOS-SDK-symbols.podspec`)
+  - Mapbox-iOS-SDK-symbols (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.6.4/platform/ios/Mapbox-iOS-SDK-symbols.podspec`)
 
 EXTERNAL SOURCES:
   Mapbox-iOS-SDK-symbols:
-    :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.6.3/platform/ios/Mapbox-iOS-SDK-symbols.podspec
+    :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.6.4/platform/ios/Mapbox-iOS-SDK-symbols.podspec
 
 SPEC CHECKSUMS:
-  Mapbox-iOS-SDK-symbols: c3a077d2d84ddde5e6a487eed5261a035808f3f4
+  Mapbox-iOS-SDK-symbols: 3592d8c94829dd1249a612e4f651c22c38c63453
 
-PODFILE CHECKSUM: eea2b846c309a9c4343e45d85a7b9c07421d9eec
+PODFILE CHECKSUM: 63472e233b1ba9e02417ce48ddd2f15c1105f8c4
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.4.0.beta.1


### PR DESCRIPTION
https://github.com/mapbox/mapbox-gl-native/releases/tag/ios-v3.6.4

/cc @captainbarbosa @jmkiley 