### PR TITLE
Add tutorial code from mapbox.com/help

### DIFF
--- a/DocsCode/DDSCircleLayerTutorial/DDSCircleLayerTutorialViewController.h
+++ b/DocsCode/DDSCircleLayerTutorial/DDSCircleLayerTutorialViewController.h
@@ -1,0 +1,5 @@
+#import <UIKit/UIKit.h>
+
+@interface DDSCircleLayerTutorialViewController : UIViewController
+
+@end

--- a/DocsCode/DDSCircleLayerTutorial/DDSCircleLayerTutorialViewController.m
+++ b/DocsCode/DDSCircleLayerTutorial/DDSCircleLayerTutorialViewController.m
@@ -38,7 +38,7 @@
     // #-end-code-snippet: dds-circle add-vector-source-objc
 
     // #-code-snippet: dds-circle add-circle-layer-objc
-    MGLCircleStyleLayer *layer = [[MGLCircleStyleLayer alloc] initWithIdentifier: @"tree-style" source:source];
+    MGLCircleStyleLayer *layer = [[MGLCircleStyleLayer alloc] initWithIdentifier:@"tree-style" source:source];
     
     // The source name from the source's TileJSON metadata: mapbox.com/api-documentation/#retrieve-tilejson-metadata
     layer.sourceLayerIdentifier = @"yoshino-trees-a0puw5";
@@ -56,10 +56,10 @@
     
     // #-code-snippet: dds-circle add-style-layer-objc
     // Style the circle layer color based on the above categorical stops.
-    layer.circleColor = [MGLStyleValue valueWithInterpolationMode: MGLInterpolationModeInterval
-                                                      sourceStops: stops
-                                                    attributeName: @"AGE"
-                                                          options: nil];
+    layer.circleColor = [MGLStyleValue valueWithInterpolationMode:MGLInterpolationModeInterval
+                                                      sourceStops:stops
+                                                    attributeName:@"AGE"
+                                                          options:nil];
     
     layer.circleRadius = [MGLStyleValue valueWithRawValue:@3];
     

--- a/DocsCode/DDSCircleLayerTutorial/DDSCircleLayerTutorialViewController.m
+++ b/DocsCode/DDSCircleLayerTutorial/DDSCircleLayerTutorialViewController.m
@@ -1,0 +1,70 @@
+#import "DDSCircleLayerTutorialViewController.h"
+
+@import Mapbox;
+
+@interface DDSCircleLayerTutorialViewController () <MGLMapViewDelegate>
+
+@end
+
+@implementation DDSCircleLayerTutorialViewController
+
+// #-code-snippet: dds-circle initialize-map-objc
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    // Create a new map view using the Mapbox Light style.
+    MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL: [MGLStyle lightStyleURL]];
+    
+    mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    mapView.tintColor = [UIColor darkGrayColor];
+    
+    // Set the map’s center coordinate and zoom level.
+    mapView.centerCoordinate = CLLocationCoordinate2DMake(38.897, -77.039);
+    mapView.zoomLevel = 10.5;
+    
+    [self.view addSubview:mapView];
+    mapView.delegate = self;
+}
+// #-end-code-snippet: dds-circle initialize-map-objc
+
+// Wait until the style is loaded before modifying the map style.
+- (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {
+    // #-code-snippet: dds-circle add-vector-source-objc
+    // "mapbox://examples.2uf7qges" is the map ID referencing a tileset
+    // created from the GeoJSON data uploaded earlier.
+    MGLSource *source = [[MGLVectorSource alloc] initWithIdentifier:@"trees" configurationURL:[NSURL URLWithString:@"mapbox://examples.2uf7qges"]];
+    
+    [mapView.style addSource:source];
+    // #-end-code-snippet: dds-circle add-vector-source-objc
+
+    // #-code-snippet: dds-circle add-circle-layer-objc
+    MGLCircleStyleLayer *layer = [[MGLCircleStyleLayer alloc] initWithIdentifier: @"tree-style" source:source];
+    
+    // The source name from the source's TileJSON metadata: mapbox.com/api-documentation/#retrieve-tilejson-metadata
+    layer.sourceLayerIdentifier = @"yoshino-trees-a0puw5";
+    // #-end-code-snippet: dds-circle add-circle-layer-objc
+    
+    // #-code-snippet: dds-circle add-stops-dictionary-objc
+    NSDictionary *stops = @{
+        @0: [MGLStyleValue valueWithRawValue:[UIColor colorWithRed:1.00 green:0.72 blue:0.85 alpha:1.0]],
+        @2: [MGLStyleValue valueWithRawValue:[UIColor colorWithRed:0.69 green:0.48 blue:0.73 alpha:1.0]],
+        @4: [MGLStyleValue valueWithRawValue:[UIColor colorWithRed:0.61 green:0.31 blue:0.47 alpha:1.0]],
+        @7: [MGLStyleValue valueWithRawValue:[UIColor colorWithRed:0.43 green:0.20 blue:0.38 alpha:1.0]],
+        @16: [MGLStyleValue valueWithRawValue:[UIColor colorWithRed:0.33 green:0.17 blue:0.25 alpha:1.0]]
+    };
+    // #-end-code-snippet: dds-circle add-stops-dictionary-objc
+    
+    // #-code-snippet: dds-circle add-style-layer-objc
+    // Style the circle layer color based on the above categorical stops.
+    layer.circleColor = [MGLStyleValue valueWithInterpolationMode: MGLInterpolationModeInterval
+                                                      sourceStops: stops
+                                                    attributeName: @"AGE"
+                                                          options: nil];
+    
+    layer.circleRadius = [MGLStyleValue valueWithRawValue:@3];
+    
+    [mapView.style addLayer:layer];
+    // #-end-code-snippet: dds-circle add-style-layer-objc
+}
+
+@end

--- a/DocsCode/DDSCircleLayerTutorial/DDSCircleLayerTutorialViewController.swift
+++ b/DocsCode/DDSCircleLayerTutorial/DDSCircleLayerTutorialViewController.swift
@@ -1,0 +1,62 @@
+import UIKit
+import Mapbox
+
+class DDSCircleLayerTutorialViewController: UIViewController, MGLMapViewDelegate {
+    
+    // #-code-snippet: dds-circle initialize-map-swift
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Create a new map view using the Mapbox Light style.
+        let mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.lightStyleURL())
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        mapView.tintColor = .darkGray
+        
+        // Set the map’s center coordinate and zoom level.
+        mapView.setCenter(CLLocationCoordinate2D(latitude: 38.897, longitude: -77.039), zoomLevel: 10.5, animated: false)
+        
+        view.addSubview(mapView)
+        mapView.delegate = self
+    }
+    // #-end-code-snippet: dds-circle initialize-map-swift
+
+    
+    // Wait until the style is loaded before modifying the map style.
+    func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
+        // #-code-snippet: dds-circle add-vector-source-swift
+        // "mapbox://examples.2uf7qges" is the map ID referencing a tileset
+        // created from the GeoJSON data uploaded earlier.
+        let source = MGLVectorSource(identifier: "trees", configurationURL: URL(string: "mapbox://examples.2uf7qges")!)
+        
+        style.addSource(source)
+        // #-end-code-snippet: dds-circle add-vector-source-swift
+        
+        // #-code-snippet: dds-circle add-circle-layer-swift
+        let layer = MGLCircleStyleLayer(identifier: "tree-style", source: source)
+    
+        // The source name from the source's TileJSON metadata: mapbox.com/api-documentation/#retrieve-tilejson-metadata
+        layer.sourceLayerIdentifier = "yoshino-trees-a0puw5"
+        // #-end-code-snippet: dds-circle add-circle-layer-swift
+    
+        // #-code-snippet: dds-circle add-stops-dictionary-swift
+        let stops = [
+            0: MGLStyleValue(rawValue: UIColor(red:1.00, green:0.72, blue:0.85, alpha:1.0)),
+            2: MGLStyleValue(rawValue: UIColor(red:0.69, green:0.48, blue:0.73, alpha:1.0)),
+            4: MGLStyleValue(rawValue: UIColor(red:0.61, green:0.31, blue:0.47, alpha:1.0)),
+            7: MGLStyleValue(rawValue: UIColor(red:0.43, green:0.20, blue:0.38, alpha:1.0)),
+            16: MGLStyleValue(rawValue: UIColor(red:0.33, green:0.17, blue:0.25, alpha:1.0))
+        ]
+        // #-end-code-snippet: dds-circle add-stops-dictionary-swift
+        
+        // #-code-snippet: dds-circle add-style-layer-swift
+        layer.circleColor = MGLStyleValue<UIColor>(interpolationMode: .interval,
+        sourceStops: stops,
+        attributeName: "AGE",
+        options: nil)
+        
+        layer.circleRadius = MGLStyleValue(rawValue: 3)
+        
+        style.addLayer(layer)
+        // #-end-code-snippet: dds-circle add-style-layer-swift
+    }
+}

--- a/DocsCode/DDSCircleLayerTutorial/DDSCircleLayerTutorialViewController.swift
+++ b/DocsCode/DDSCircleLayerTutorial/DDSCircleLayerTutorialViewController.swift
@@ -50,9 +50,9 @@ class DDSCircleLayerTutorialViewController: UIViewController, MGLMapViewDelegate
         
         // #-code-snippet: dds-circle add-style-layer-swift
         layer.circleColor = MGLStyleValue<UIColor>(interpolationMode: .interval,
-        sourceStops: stops,
-        attributeName: "AGE",
-        options: nil)
+                                                   sourceStops: stops,
+                                                   attributeName: "AGE",
+                                                   options: nil)
         
         layer.circleRadius = MGLStyleValue(rawValue: 3)
         

--- a/DocsCode/FirstStepsTutorial/FirstStepsTutorialViewController.m
+++ b/DocsCode/FirstStepsTutorial/FirstStepsTutorialViewController.m
@@ -17,11 +17,11 @@
                        zoomLevel:9
                         animated:NO];
     [self.view addSubview:mapView];
-    // #-end-code-snippet
+    // #-end-code-snippet: first-steps-ios-sdk initialize-map-objc
     
     // #-code-snippet: first-steps-ios-sdk change-style-objc
     mapView.styleURL = [MGLStyle satelliteStreetsStyleURL];
-    // #-end-code-snippet
+    // #-end-code-snippet: first-steps-ios-sdk change-style-objc
     
     // #-code-snippet: first-steps-ios-sdk add-annotation-objc
     // Add a point annotation
@@ -30,24 +30,24 @@
     annotation.title = @"Central Park";
     annotation.subtitle = @"The best park in New York City!";
     [mapView addAnnotation:annotation];
-    // #-end-code-snippet
+    // #-end-code-snippet: first-steps-ios-sdk add-annotation-objc
     
     // #-code-snippet: first-steps-ios-sdk show-location-objc
     // Allow the map view to display the user's location
     mapView.showsUserLocation = YES;
-    // #-end-code-snippet
+    // #-end-code-snippet: first-steps-ios-sdk show-location-objc
     
     // #-code-snippet: first-steps-ios-sdk set-delegate-objc
     // Set the map view's delegate
     mapView.delegate = self;
-    // #-end-code-snippet
+    // #-end-code-snippet: first-steps-ios-sdk set-delegate-objc
 }
 
-// #-code-snippet: first-steps-ios-sdk add-callout-objc
+// #-code-snippet: first-steps-ios-sdk can-show-callout-objc
 - (BOOL)mapView:(MGLMapView *)mapView annotationCanShowCallout:(id<MGLAnnotation>)annotation {
     // Always allow callouts to popup when annotations are tapped.
     return YES;
-    // #-end-code-snippet
 }
+// #-end-code-snippet: first-steps-ios-sdk can-show-callout-objc
 
 @end

--- a/DocsCode/FirstStepsTutorial/FirstStepsTutorialViewController.m
+++ b/DocsCode/FirstStepsTutorial/FirstStepsTutorialViewController.m
@@ -10,31 +10,44 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds
-                                                   styleURL:[MGLStyle satelliteStreetsStyleURL]];
+    // #-code-snippet: first-steps-ios-sdk initialize-map-objc
+    MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
     mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     [mapView setCenterCoordinate:CLLocationCoordinate2DMake(40.74699, -73.98742)
                        zoomLevel:9
                         animated:NO];
     [self.view addSubview:mapView];
+    // #-end-code-snippet
     
+    // #-code-snippet: first-steps-ios-sdk change-style-objc
+    mapView.styleURL = [MGLStyle satelliteStreetsStyleURL];
+    // #-end-code-snippet
+    
+    // #-code-snippet: first-steps-ios-sdk add-annotation-objc
     // Add a point annotation
     MGLPointAnnotation *annotation = [[MGLPointAnnotation alloc] init];
     annotation.coordinate = CLLocationCoordinate2DMake(40.77014, -73.97480);
     annotation.title = @"Central Park";
     annotation.subtitle = @"The best park in New York City!";
     [mapView addAnnotation:annotation];
+    // #-end-code-snippet
     
+    // #-code-snippet: first-steps-ios-sdk show-location-objc
     // Allow the map view to display the user's location
     mapView.showsUserLocation = YES;
+    // #-end-code-snippet
     
+    // #-code-snippet: first-steps-ios-sdk set-delegate-objc
     // Set the map view's delegate
     mapView.delegate = self;
+    // #-end-code-snippet
 }
 
+// #-code-snippet: first-steps-ios-sdk add-callout-objc
 - (BOOL)mapView:(MGLMapView *)mapView annotationCanShowCallout:(id<MGLAnnotation>)annotation {
     // Always allow callouts to popup when annotations are tapped.
     return YES;
+    // #-end-code-snippet
 }
 
 @end

--- a/DocsCode/FirstStepsTutorial/FirstStepsTutorialViewController.swift
+++ b/DocsCode/FirstStepsTutorial/FirstStepsTutorialViewController.swift
@@ -10,11 +10,11 @@ class FirstStepsTutorialViewController: UIViewController, MGLMapViewDelegate {
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.setCenter(CLLocationCoordinate2D(latitude: 40.74699, longitude: -73.98742), zoomLevel: 9, animated: false)
         view.addSubview(mapView)
-        // #-end-code-snippet
+        // #-end-code-snippet: first-steps-ios-sdk initialize-map-swift
         
         // #-code-snippet: first-steps-ios-sdk change-style-swift
         mapView.styleURL = MGLStyle.satelliteStyleURL()
-        // #-end-code-snippet
+        // #-end-code-snippet: first-steps-ios-sdk change-style-swift
         
         // #-code-snippet: first-steps-ios-sdk add-annotation-swift
         // Add a point annotation
@@ -23,24 +23,23 @@ class FirstStepsTutorialViewController: UIViewController, MGLMapViewDelegate {
         annotation.title = "Central Park"
         annotation.subtitle = "The biggest park in New York City!"
         mapView.addAnnotation(annotation)
-        // #-end-code-snippet
-        
-        // #-code-snippet: first-steps-ios-sdk show-location-swift
-        // Allow the map view to display the user's location
-        mapView.showsUserLocation = true
-        // #-end-code-snippet
+        // #-end-code-snippet: first-steps-ios-sdk add-annotation-swift
         
         // #-code-snippet: first-steps-ios-sdk set-delegate-swift
         // Set the map view's delegate
         mapView.delegate = self
-        // #-end-code-snippet
+        // #-end-code-snippet: first-steps-ios-sdk set-delegate-swift
         
+        // #-code-snippet: first-steps-ios-sdk show-location-swift
+        // Allow the map view to display the user's location
+        mapView.showsUserLocation = true
+        // #-end-code-snippet: first-steps-ios-sdk show-location-swift
     }
     
-    // #-code-snippet: first-steps-ios-sdk add-callout-swift
+    // #-code-snippet: first-steps-ios-sdk can-show-callout-swift
     func mapView(_ mapView: MGLMapView, annotationCanShowCallout annotation: MGLAnnotation) -> Bool {
         // Always allow callouts to popup when annotations are tapped.
         return true
     }
-    // #-end-code-snippet
+    // #-end-code-snippet: first-steps-ios-sdk can-show-callout-swift
 }

--- a/DocsCode/FirstStepsTutorial/FirstStepsTutorialViewController.swift
+++ b/DocsCode/FirstStepsTutorial/FirstStepsTutorialViewController.swift
@@ -2,30 +2,45 @@ import Mapbox
 
 class FirstStepsTutorialViewController: UIViewController, MGLMapViewDelegate {
     override func viewDidLoad() {
+        
         super.viewDidLoad()
         
-        let mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.satelliteStreetsStyleURL())
+        // #-code-snippet: first-steps-ios-sdk initialize-map-swift
+        let mapView = MGLMapView(frame: view.bounds)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.setCenter(CLLocationCoordinate2D(latitude: 40.74699, longitude: -73.98742), zoomLevel: 9, animated: false)
         view.addSubview(mapView)
+        // #-end-code-snippet
         
+        // #-code-snippet: first-steps-ios-sdk change-style-swift
+        mapView.styleURL = MGLStyle.satelliteStyleURL()
+        // #-end-code-snippet
+        
+        // #-code-snippet: first-steps-ios-sdk add-annotation-swift
         // Add a point annotation
         let annotation = MGLPointAnnotation()
         annotation.coordinate = CLLocationCoordinate2D(latitude: 40.77014, longitude: -73.97480)
         annotation.title = "Central Park"
         annotation.subtitle = "The biggest park in New York City!"
         mapView.addAnnotation(annotation)
+        // #-end-code-snippet
         
+        // #-code-snippet: first-steps-ios-sdk show-location-swift
         // Allow the map view to display the user's location
         mapView.showsUserLocation = true
+        // #-end-code-snippet
         
+        // #-code-snippet: first-steps-ios-sdk set-delegate-swift
         // Set the map view's delegate
         mapView.delegate = self
+        // #-end-code-snippet
+        
     }
     
+    // #-code-snippet: first-steps-ios-sdk add-callout-swift
     func mapView(_ mapView: MGLMapView, annotationCanShowCallout annotation: MGLAnnotation) -> Bool {
         // Always allow callouts to popup when annotations are tapped.
         return true
     }
+    // #-end-code-snippet
 }
-

--- a/DocsCode/FirstStepsTutorial/FirstStepsTutorialViewController.swift
+++ b/DocsCode/FirstStepsTutorial/FirstStepsTutorialViewController.swift
@@ -42,4 +42,12 @@ class FirstStepsTutorialViewController: UIViewController, MGLMapViewDelegate {
         return true
     }
     // #-end-code-snippet: first-steps-ios-sdk can-show-callout-swift
+    
+    // #-code-snippet: first-steps-ios-sdk fly-to-annotation-swift
+    func mapView(_ mapView: MGLMapView, didSelect annotation: MGLAnnotation) {
+        let camera = MGLMapCamera(lookingAtCenter: annotation.coordinate, fromDistance: 4500, pitch: 15, heading: 180)
+        mapView.fly(to: camera, withDuration: 4,
+                    peakAltitude: 3000, completionHandler: nil)
+    }
+    // #-end-code-snippet: first-steps-ios-sdk fly-to-annotation-swift
 }

--- a/DocsCode/Info.plist
+++ b/DocsCode/Info.plist
@@ -4,6 +4,10 @@
 <dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>For testing purposes only</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.h
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.h
@@ -1,0 +1,5 @@
+#import <UIKit/UIKit.h>
+
+@interface NavigationTutorialViewController : UIViewController
+
+@end

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
@@ -1,0 +1,155 @@
+// #-code-snippet: navigation full-tutorial-objc
+// #-code-snippet: navigation dependencies-objc
+#import "NavigationTutorialViewController"
+
+@import Mapbox;
+@import MapboxCoreNavigation;
+@import MapboxNavigation;
+@import MapboxDirections;
+// #-end-code-snippet: navigation dependencies-objc
+
+@interface NavigationTutorialViewController () <MGLMapViewDelegate>
+
+// #-code-snippet: navigation mapview-property-objc
+@property (nonatomic) MGLMapView *mapView;
+// #-end-code-snippet: navigation mapview-property-objc
+
+// #-code-snippet: navigation directions-route-objc
+@property (nonatomic) MBRoute *directionsRoute;
+// #-end-code-snippet: navigation directions-route-objc
+
+
+@end
+
+@implementation NavigationTutorialViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
+    // #-code-snippet: navigation init-map-objc
+    self.mapView = [[MBNavigationMapView alloc] initWithFrame:self.view.bounds styleURL: [MGLStyle streetsStyleURL]];
+    [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(30.265, -97.741)
+                            zoomLevel:11 animated:NO];
+    [self.view addSubview:self.mapView];
+    // Set the map view's delegate
+    self.mapView.delegate = self;
+    // #-end-code-snippet: navigation init-map-objc
+    
+    // #-code-snippet: navigation user-location-objc
+    // Allow the map view to display the user's location
+    self.mapView.showsUserLocation = YES;
+    // #-end-code-snippet: navigation user-location-objc
+    
+    // #-code-snippet: navigation gesture-recognizer-objc
+    UITapGestureRecognizer *setDestination = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(didLongPress:)];
+    [self.mapView addGestureRecognizer:setDestination];
+    // #-end-code-snippet: navigation gesture-recognizer-objc
+}
+
+// #-code-snippet: navigation allow-callouts-objc
+// Implement the delegate method that allows annotations to show callouts when tapped
+-(BOOL)mapView:(MGLMapView *)mapView annotationCanShowCallout:(id<MGLAnnotation>)annotation {
+    return true;
+}
+// #-end-code-snippet: navigation allow-callouts-objc
+
+// #-code-snippet: navigation long-press-objc
+-(void)didLongPress:(UITapGestureRecognizer *)sender {
+    if (sender.state != UIGestureRecognizerStateEnded) {
+        return;
+    }
+    
+    // Converts point where user did a long press to map coordinates
+    CGPoint point = [sender locationInView:self.mapView];
+    CLLocationCoordinate2D coordinate = [self.mapView convertPoint:point toCoordinateFromView:self.mapView];
+    
+    // Create a basic point annotation and add it to the map
+    MGLPointAnnotation *annotation = [MGLPointAnnotation alloc];
+    annotation.coordinate = coordinate;
+    annotation.title = @"Start navigtation";
+    [self.mapView addAnnotation:annotation];
+    
+    // #-code-snippet: navigation call-calculate-route-objc
+    [self calculateRoutefromOrigin:self.mapView.userLocation.coordinate
+                     toDestination:annotation.coordinate
+                        completion:^(MBRoute * _Nullable route, NSError * _Nullable error) {
+                            if (error != nil) {
+                                printf("Error calculating route");
+                            }
+                        }];
+    // #-end-code-snippet: navigation call-calculate-route-objc
+}
+// #-end-code-snippet: navigation long-press-objc
+
+// #-code-snippet: navigation calculate-route-objc
+-(void)calculateRoutefromOrigin:(CLLocationCoordinate2D)origin
+                 toDestination :(CLLocationCoordinate2D)destination
+                     completion:(void(^)(MBRoute *_Nullable route, NSError *_Nullable error))completion {
+    
+    MBWaypoint *originWaypoint = [[MBWaypoint alloc] initWithCoordinate:origin coordinateAccuracy:-1 name:@"University of Texas at Austin"];
+    
+    MBWaypoint *destinationWaypoint = [[MBWaypoint alloc] initWithCoordinate:destination coordinateAccuracy:-1 name:@"Tacodeli"];
+    
+    MBNavigationRouteOptions *options = [[MBNavigationRouteOptions alloc] initWithWaypoints:@[originWaypoint, destinationWaypoint] profileIdentifier:MBDirectionsProfileIdentifierAutomobileAvoidingTraffic];
+    
+    NSURLSessionDataTask *task = [[MBDirections sharedDirections] calculateDirectionsWithOptions:options completionHandler:^(NSArray<MBWaypoint *> * _Nullable waypoints, NSArray<MBRoute *> * _Nullable routes, NSError * _Nullable error){
+        
+        if (!routes.firstObject) {
+            return;
+        }
+        
+        MBRoute *route = routes.firstObject;
+        self.directionsRoute = route;
+        CLLocationCoordinate2D *routeCoordinates = malloc(route.coordinateCount * sizeof(CLLocationCoordinate2D));
+        [route getCoordinates:routeCoordinates];
+        [self drawRoute:routeCoordinates];
+    }];
+}
+// #-end-code-snippet: navigation calculate-route-objc
+
+// #-code-snippet: navigation draw-route-objc
+-(void)drawRoute:(CLLocationCoordinate2D *)route {
+    if (self.directionsRoute.coordinateCount == 0) {
+        return;
+    }
+    
+    // Convert the route’s coordinates into a polyline.
+    MGLPolylineFeature *polyline = [MGLPolylineFeature polylineWithCoordinates:route count:self.directionsRoute.coordinateCount];
+    
+    if ([self.mapView.style sourceWithIdentifier:@"route-source"]) {
+        // If there's already a route line on the map, reset its shape to the new route
+        MGLShapeSource *source = [self.mapView.style sourceWithIdentifier:@"route-source"];
+        source.shape = polyline;
+    } else {
+        MGLShapeSource *source = [[MGLShapeSource alloc] initWithIdentifier:@"route-source" shape:polyline options:nil];
+        MGLLineStyleLayer *lineStyle = [[MGLLineStyleLayer alloc] initWithIdentifier:@"route-style" source:source];
+        // #-code-snippet: navigation route-style-objc
+        lineStyle.lineColor = [MGLStyleValue valueWithRawValue:[UIColor blueColor]];
+        lineStyle.lineWidth = [MGLStyleValue valueWithRawValue:@"3"];
+        // #-end-code-snippet: navigation route-style-objc
+        [self.mapView.style addSource:source];
+        [self.mapView.style addLayer:lineStyle];
+    }
+    
+}
+// #-end-code-snippet: navigation draw-route-objc
+
+// #-code-snippet: navigation present-navigation-objc
+-(void)presentNavigation:(MBRoute *)route {
+    MBNavigationViewController *viewController = [[MBNavigationViewController alloc] initWithRoute:route
+           directions:[MBDirections sharedDirections]
+                style:nil
+      locationManager:_mapView.locationManager];
+    
+    [self presentViewController:viewController animated:YES completion:nil];
+}
+// #-end-code-snippet: navigation present-navigation-objc
+
+// #-code-snippet: navigation callout-tap-objc
+-(void)mapView:(MGLMapView *)mapView tapOnCalloutForAnnotation:(id<MGLAnnotation>)annotation {
+    [self presentNavigation:_directionsRoute];
+}
+// #-end-code-snippet: navigation callout-tap-objc
+
+@end
+// #-end-code-snippet: navigation full-tutorial-objc

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
@@ -92,7 +92,10 @@
     MBNavigationRouteOptions *options = [[MBNavigationRouteOptions alloc] initWithWaypoints:@[originWaypoint, destinationWaypoint] profileIdentifier:MBDirectionsProfileIdentifierAutomobileAvoidingTraffic];
     
     // Generate the route object and draw it on the map
-    NSURLSessionDataTask *task = [[MBDirections sharedDirections] calculateDirectionsWithOptions:options completionHandler:^(NSArray<MBWaypoint *> * _Nullable waypoints, NSArray<MBRoute *> * _Nullable routes, NSError * _Nullable error){
+    NSURLSessionDataTask *task = [[MBDirections sharedDirections] calculateDirectionsWithOptions:options completionHandler:^(
+            NSArray<MBWaypoint *> *waypoints,
+            NSArray<MBRoute *> *routes,
+            NSError *error) {
         
         if (!routes.firstObject) {
             return;

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
@@ -39,7 +39,7 @@
     
     // #-code-snippet: navigation gesture-recognizer-objc
     // Add a gesture recognizer to the map view
-    UITapGestureRecognizer *setDestination = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(didLongPress:)];
+    UILongPressGestureRecognizer *setDestination = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(didLongPress:)];
     [self.mapView addGestureRecognizer:setDestination];
     // #-end-code-snippet: navigation gesture-recognizer-objc
 }

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
@@ -80,7 +80,7 @@
 
 // #-code-snippet: navigation calculate-route-objc
 -(void)calculateRoutefromOrigin:(CLLocationCoordinate2D)origin
-                 toDestination :(CLLocationCoordinate2D)destination
+                  toDestination:(CLLocationCoordinate2D)destination
                      completion:(void(^)(MBRoute *_Nullable route, NSError *_Nullable error))completion {
     
     // Coordinate accuracy is the maximum distance away from the waypoint that the route may still be considered viable, measured in meters. Negative values indicate that a indefinite number of meters away from the route and still be considered viable.

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
@@ -93,9 +93,9 @@
     
     // Generate the route object and draw it on the map
     NSURLSessionDataTask *task = [[MBDirections sharedDirections] calculateDirectionsWithOptions:options completionHandler:^(
-            NSArray<MBWaypoint *> *waypoints,
-            NSArray<MBRoute *> *routes,
-            NSError *error) {
+        NSArray<MBWaypoint *> *waypoints,
+        NSArray<MBRoute *> *routes,
+        NSError *error) {
         
         if (!routes.firstObject) {
             return;

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
@@ -1,5 +1,5 @@
 // #-code-snippet: navigation dependencies-objc
-#import "NavigationTutorialViewController"
+#import "NavigationTutorialViewController.h"
 
 @import Mapbox;
 @import MapboxCoreNavigation;
@@ -9,7 +9,7 @@
 
 @interface NavigationTutorialViewController () <MGLMapViewDelegate>
 
-@property (nonatomic) MGLMapView *mapView;
+@property (nonatomic) MBNavigationMapView *mapView;
 // #-code-snippet: navigation directions-route-objc
 @property (nonatomic) MBRoute *directionsRoute;
 // #-end-code-snippet: navigation directions-route-objc
@@ -23,7 +23,8 @@
     [super viewDidLoad];
     
     // #-code-snippet: navigation init-map-objc
-    self.mapView = [[MBNavigationMapView alloc] initWithFrame:self.view.bounds styleURL: [MGLStyle streetsStyleURL]];
+    self.mapView = [[MBNavigationMapView alloc] initWithFrame:self.view.bounds];
+
     [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(30.265, -97.741)
                             zoomLevel:11 animated:NO];
     [self.view addSubview:self.mapView];
@@ -135,20 +136,10 @@
 }
 // #-end-code-snippet: navigation draw-route-objc
 
-// #-code-snippet: navigation present-navigation-objc
--(void)presentNavigation:(MBRoute *)route {
-    MBNavigationViewController *viewController = [[MBNavigationViewController alloc] initWithRoute:route
-           directions:[MBDirections sharedDirections]
-                style:nil
-      locationManager:_mapView.locationManager];
-    
-    [self presentViewController:viewController animated:YES completion:nil];
-}
-// #-end-code-snippet: navigation present-navigation-objc
-
 // #-code-snippet: navigation tap-callout-objc
 -(void)mapView:(MGLMapView *)mapView tapOnCalloutForAnnotation:(id<MGLAnnotation>)annotation {
-    [self presentNavigation:_directionsRoute];
+    MBNavigationViewController *navigationViewController = [[MBNavigationViewController alloc] initWithRoute:_directionsRoute directions:[MBDirections sharedDirections] style:nil locationManager:nil];
+    [self presentViewController:navigationViewController animated:YES completion:nil];
 }
 // #-end-code-snippet: navigation tap-callout-objc
 

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
@@ -74,7 +74,7 @@
                             if (error != nil) {
                                 NSLog(@"Error calculating route");
                             }
-                        }];
+    }];
 }
 // #-end-code-snippet: navigation long-press-objc
 

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
@@ -72,7 +72,7 @@
                      toDestination:annotation.coordinate
                         completion:^(MBRoute * _Nullable route, NSError * _Nullable error) {
                             if (error != nil) {
-                                NSLog(@"Error calculating route");
+                                NSLog(@"Error calculating route: %@", error);
                             }
     }];
 }

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
@@ -83,6 +83,7 @@
                  toDestination :(CLLocationCoordinate2D)destination
                      completion:(void(^)(MBRoute *_Nullable route, NSError *_Nullable error))completion {
     
+    // Coordinate accuracy is the maximum distance away from the waypoint that the route may still be considered viable, measured in meters. Negative values indicate that a indefinite number of meters away from the route and still be considered viable.
     MBWaypoint *originWaypoint = [[MBWaypoint alloc] initWithCoordinate:origin coordinateAccuracy:-1 name:@"Start"];
     
     MBWaypoint *destinationWaypoint = [[MBWaypoint alloc] initWithCoordinate:destination coordinateAccuracy:-1 name:@"Finish"];

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
@@ -92,7 +92,7 @@
     MBNavigationRouteOptions *options = [[MBNavigationRouteOptions alloc] initWithWaypoints:@[originWaypoint, destinationWaypoint] profileIdentifier:MBDirectionsProfileIdentifierAutomobileAvoidingTraffic];
     
     // Generate the route object and draw it on the map
-    NSURLSessionDataTask *task = [[MBDirections sharedDirections] calculateDirectionsWithOptions:options completionHandler:^(
+    (void)[[MBDirections sharedDirections] calculateDirectionsWithOptions:options completionHandler:^(
         NSArray<MBWaypoint *> *waypoints,
         NSArray<MBRoute *> *routes,
         NSError *error) {

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
@@ -72,7 +72,7 @@
                      toDestination:annotation.coordinate
                         completion:^(MBRoute * _Nullable route, NSError * _Nullable error) {
                             if (error != nil) {
-                                printf("Error calculating route");
+                                NSLog(@"Error calculating route");
                             }
                         }];
 }

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
@@ -1,4 +1,3 @@
-// #-code-snippet: navigation full-tutorial-objc
 // #-code-snippet: navigation dependencies-objc
 #import "NavigationTutorialViewController"
 
@@ -10,10 +9,7 @@
 
 @interface NavigationTutorialViewController () <MGLMapViewDelegate>
 
-// #-code-snippet: navigation mapview-property-objc
 @property (nonatomic) MGLMapView *mapView;
-// #-end-code-snippet: navigation mapview-property-objc
-
 // #-code-snippet: navigation directions-route-objc
 @property (nonatomic) MBRoute *directionsRoute;
 // #-end-code-snippet: navigation directions-route-objc
@@ -41,6 +37,7 @@
     // #-end-code-snippet: navigation user-location-objc
     
     // #-code-snippet: navigation gesture-recognizer-objc
+    // Add a gesture recognizer to the map view
     UITapGestureRecognizer *setDestination = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(didLongPress:)];
     [self.mapView addGestureRecognizer:setDestination];
     // #-end-code-snippet: navigation gesture-recognizer-objc
@@ -69,7 +66,7 @@
     annotation.title = @"Start navigtation";
     [self.mapView addAnnotation:annotation];
     
-    // #-code-snippet: navigation call-calculate-route-objc
+    // Calcuate the route from the user's location to the set destination
     [self calculateRoutefromOrigin:self.mapView.userLocation.coordinate
                      toDestination:annotation.coordinate
                         completion:^(MBRoute * _Nullable route, NSError * _Nullable error) {
@@ -77,7 +74,6 @@
                                 printf("Error calculating route");
                             }
                         }];
-    // #-end-code-snippet: navigation call-calculate-route-objc
 }
 // #-end-code-snippet: navigation long-press-objc
 
@@ -86,12 +82,14 @@
                  toDestination :(CLLocationCoordinate2D)destination
                      completion:(void(^)(MBRoute *_Nullable route, NSError *_Nullable error))completion {
     
-    MBWaypoint *originWaypoint = [[MBWaypoint alloc] initWithCoordinate:origin coordinateAccuracy:-1 name:@"University of Texas at Austin"];
+    MBWaypoint *originWaypoint = [[MBWaypoint alloc] initWithCoordinate:origin coordinateAccuracy:-1 name:@"Start"];
     
-    MBWaypoint *destinationWaypoint = [[MBWaypoint alloc] initWithCoordinate:destination coordinateAccuracy:-1 name:@"Tacodeli"];
+    MBWaypoint *destinationWaypoint = [[MBWaypoint alloc] initWithCoordinate:destination coordinateAccuracy:-1 name:@"Finish"];
     
+    // Specify that the route is intented for automobiles avoiding traffic
     MBNavigationRouteOptions *options = [[MBNavigationRouteOptions alloc] initWithWaypoints:@[originWaypoint, destinationWaypoint] profileIdentifier:MBDirectionsProfileIdentifierAutomobileAvoidingTraffic];
     
+    // Generate the route object and draw it on the map
     NSURLSessionDataTask *task = [[MBDirections sharedDirections] calculateDirectionsWithOptions:options completionHandler:^(NSArray<MBWaypoint *> * _Nullable waypoints, NSArray<MBRoute *> * _Nullable routes, NSError * _Nullable error){
         
         if (!routes.firstObject) {
@@ -102,6 +100,7 @@
         self.directionsRoute = route;
         CLLocationCoordinate2D *routeCoordinates = malloc(route.coordinateCount * sizeof(CLLocationCoordinate2D));
         [route getCoordinates:routeCoordinates];
+        // Draw the route on the map after creating it
         [self drawRoute:routeCoordinates];
     }];
 }
@@ -123,10 +122,12 @@
     } else {
         MGLShapeSource *source = [[MGLShapeSource alloc] initWithIdentifier:@"route-source" shape:polyline options:nil];
         MGLLineStyleLayer *lineStyle = [[MGLLineStyleLayer alloc] initWithIdentifier:@"route-style" source:source];
-        // #-code-snippet: navigation route-style-objc
+        
+        // Customize the route line color and width
         lineStyle.lineColor = [MGLStyleValue valueWithRawValue:[UIColor blueColor]];
         lineStyle.lineWidth = [MGLStyleValue valueWithRawValue:@"3"];
-        // #-end-code-snippet: navigation route-style-objc
+        
+        // Add the source and style layer of the route line to the map
         [self.mapView.style addSource:source];
         [self.mapView.style addLayer:lineStyle];
     }
@@ -145,11 +146,10 @@
 }
 // #-end-code-snippet: navigation present-navigation-objc
 
-// #-code-snippet: navigation callout-tap-objc
+// #-code-snippet: navigation tap-callout-objc
 -(void)mapView:(MGLMapView *)mapView tapOnCalloutForAnnotation:(id<MGLAnnotation>)annotation {
     [self presentNavigation:_directionsRoute];
 }
-// #-end-code-snippet: navigation callout-tap-objc
+// #-end-code-snippet: navigation tap-callout-objc
 
 @end
-// #-end-code-snippet: navigation full-tutorial-objc

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -56,7 +56,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         mapView.addAnnotation(annotation)
         
         // Calcuate the route from the user's location to the set destination
-        calculateRoute(from: (mapView.userLocation!.coordinate), to: annotation.coordinate) { [unowned self] (route, error) in
+        calculateRoute(from: (mapView.userLocation!.coordinate), to: annotation.coordinate) { (route, error) in
             if error != nil {
                 // Print an error message
                 print("Error calculating route")

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -78,7 +78,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         let options = NavigationRouteOptions(waypoints: [origin, destination], profileIdentifier: .automobileAvoidingTraffic)
         
         // Generate the route object and draw it on the map
-        _ = Directions.shared.calculate(options) { (waypoints, routes, error) in
+        Directions.shared.calculate(options) { (waypoints, routes, error) in
             self.directionsRoute = routes?.first
             // Draw the route on the map after creating it
             self.drawRoute(route: self.directionsRoute!)

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -71,8 +71,9 @@ class ViewController: UIViewController, MGLMapViewDelegate {
                         to destination: CLLocationCoordinate2D,
                         completion: @escaping (Route?, Error?) -> ()) {
         
-        let origin = Waypoint(coordinate: origin, name: "Start")
-        let destination = Waypoint(coordinate: destination, name: "Finish")
+        // Coordinate accuracy is the maximum distance away from the waypoint that the route may still be considered viable, measured in meters. Negative values indicate that a indefinite number of meters away from the route and still be considered viable.
+        let origin = Waypoint(coordinate: origin, coordinateAccuracy: -1, name: "Start")
+        let destination = Waypoint(coordinate: destination, coordinateAccuracy: -1, name: "Finish")
         
         // Specify that the route is intented for automobiles avoiding traffic
         let options = NavigationRouteOptions(waypoints: [origin, destination], profileIdentifier: .automobileAvoidingTraffic)

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -42,7 +42,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
     // #-end-code-snippet: navigation allow-callouts-swift
     
     // #-code-snippet: navigation long-press-swift
-    func didLongPress(_ sender: UILongPressGestureRecognizer) {
+    @objc func didLongPress(_ sender: UILongPressGestureRecognizer) {
         guard sender.state == .began else { return }
         
         // Converts point where user did a long press to map coordinates

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -1,0 +1,157 @@
+// #-code-snippet: navigation full-tutorial-swift
+// #-code-snippet: navigation dependencies-swift
+import Mapbox
+import MapboxCoreNavigation
+import MapboxNavigation
+import MapboxDirections
+// #-end-code-snippet: navigation dependencies-swift
+
+class ViewController: UIViewController, MGLMapViewDelegate {
+    
+    // #-code-snippet: navigation mapview-var-swift
+    var mapView: MGLMapView!
+    // #-end-code-snippet: navigation mapview-var-swift
+    
+    // #-code-snippet: navigation directions-route-swift
+    var directionsRoute: Route?
+    // #-end-code-snippet: navigation directions-route-swift
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        // #-code-snippet: navigation init-map-swift
+        mapView = NavigationMapView(frame: view.bounds, styleURL: MGLStyle.streetsStyleURL())
+        mapView.setCenter(CLLocationCoordinate2D(latitude: 30.265, longitude: -97.741), zoomLevel: 11, animated: false)
+        view.addSubview(mapView)
+        // Set the map view's delegate
+        mapView.delegate = self
+        // #-end-code-snippet: navigation init-map-swift
+        
+        // #-code-snippet: navigation user-location-swift
+        // Allow the map view to display the user's location
+        mapView.showsUserLocation = true
+        // #-end-code-snippet: navigation user-location-swift
+        
+        // #-code-snippet: navigation gesture-recognizer-swift
+        let setDestination = UILongPressGestureRecognizer(target: self, action: #selector(didLongPress(_:)))
+        mapView.addGestureRecognizer(setDestination)
+        // #-end-code-snippet: navigation gesture-recognizer-swift
+    }
+    
+    // #-code-snippet: navigation allow-callouts-swift
+    // Implement the delegate method that allows annotations to show callouts when tapped
+    func mapView(_ mapView: MGLMapView, annotationCanShowCallout annotation: MGLAnnotation) -> Bool {
+        return true
+    }
+    // #-end-code-snippet: navigation allow-callouts-swift
+    
+    // #-code-snippet: navigation long-press-swift
+    func didLongPress(_ sender: UILongPressGestureRecognizer) {
+        guard sender.state == .began else { return }
+        
+        // Converts point where user did a long press to map coordinates
+        let point = sender.location(in: mapView)
+        let coordinate = mapView.convert(point, toCoordinateFrom: mapView)
+        
+        // Create a basic point annotation and add it to the map
+        let annotation = MGLPointAnnotation()
+        annotation.coordinate = coordinate
+        annotation.title = "Start navigation"
+        mapView.addAnnotation(annotation)
+        
+        // #-code-snippet: navigation call-calculate-route-swift
+        calculateRoute(from: (mapView.userLocation!.coordinate), to: annotation.coordinate) { [unowned self] (route, error) in
+            if error != nil {
+                // Print an error message
+                print("Error calculating route")
+            }
+        }
+        // #-end-code-snippet: navigation call-calculate-route-swift
+    }
+    // #-end-code-snippet: navigation long-press-swift
+    
+    // #-code-snippet: navigation calculate-route-swift
+    // Calculate route to be used for navigation
+    func calculateRoute(from origin: CLLocationCoordinate2D,
+                        to destination: CLLocationCoordinate2D,
+                        completion: @escaping (Route?, Error?) -> ()) {
+        
+        let origin = Waypoint(coordinate: origin, name: "Start")
+        
+        let destination = Waypoint(coordinate: destination, name: "Finish")
+        
+        let options = NavigationRouteOptions(waypoints: [origin, destination], profileIdentifier: .automobileAvoidingTraffic)
+        
+        _ = Directions.shared.calculate(options) { (waypoints, routes, error) in
+            guard let route = routes?.first else { return }
+            self.directionsRoute = route
+            self.drawRoute(route: self.directionsRoute!)
+        }
+    }
+    // #-end-code-snippet: navigation calculate-route-swift
+    
+    // #-code-snippet: navigation draw-route-swift
+    func drawRoute(route: Route) {
+        guard route.coordinateCount > 0 else { return }
+        // Convert the route’s coordinates into a polyline.
+        var routeCoordinates = route.coordinates!
+        let polyline = MGLPolylineFeature(coordinates: &routeCoordinates, count: route.coordinateCount)
+        
+        // If there's already a route line on the map, reset its shape to the new route
+        if let source = mapView.style?.source(withIdentifier: "route-source") as? MGLShapeSource {
+            source.shape = polyline
+        } else {
+            let source = MGLShapeSource(identifier: "route-source", features: [polyline], options: nil)
+            // #-code-snippet: navigation route-style-swift
+            let lineStyle = MGLLineStyleLayer(identifier: "route-style", source: source)
+            lineStyle.lineColor = MGLStyleValue(rawValue:  #colorLiteral(red: 0.1897518039, green: 0.3010634184, blue: 0.7994888425, alpha: 1))
+            lineStyle.lineWidth = MGLStyleValue(rawValue: 3)
+            // #-end-code-snippet: navigation route-style-swift
+            
+            mapView.style?.addSource(source)
+            mapView.style?.addLayer(lineStyle)
+        }
+    }
+    // #-end-code-snippet: navigation draw-route-swift
+    
+    // #-code-snippet: navigation present-navigation-swift
+    func presentNavigation(along route: Route) {
+        class CustomStyle: DayStyle {
+            
+            public required init() {
+                super.init()
+                mapStyleURL = URL(string: "mapbox://styles/mapbox/light-v9")!
+            }
+            
+            override func apply() {
+                super.apply()
+                ManeuverView.appearance().backgroundColor =  #colorLiteral(red: 0.1897518039, green: 0.3010634184, blue: 0.7994888425, alpha: 1)
+                RouteTableViewHeaderView.appearance().backgroundColor =  #colorLiteral(red: 0.1897518039, green: 0.3010634184, blue: 0.7994888425, alpha: 1)
+                Button.appearance().textColor = .white
+                WayNameLabel.appearance().textColor = .white
+                DistanceLabel.appearance().textColor = .white
+                DestinationLabel.appearance().textColor = .white
+                ArrivalTimeLabel.appearance().textColor = .white
+                TimeRemainingLabel.appearance().textColor = .white
+                DistanceRemainingLabel.appearance().textColor = .white
+                TurnArrowView.appearance().primaryColor = .white
+                TurnArrowView.appearance().secondaryColor = .white
+                LanesView.appearance().backgroundColor = .white
+                LaneArrowView.appearance().primaryColor = .white
+                CancelButton.appearance().tintColor = .white
+            }
+        }
+        
+        let viewController = NavigationViewController(for: route, styles: [CustomStyle()])
+        self.present(viewController, animated: true, completion: nil)
+    }
+    // #-end-code-snippet: navigation present-navigation-swift
+    
+    // #-code-snippet: navigation callout-tap-swift
+    func mapView(_ mapView: MGLMapView, tapOnCalloutFor annotation: MGLAnnotation) {
+        self.presentNavigation(along: directionsRoute!)
+    }
+    // #-end-code-snippet: navigation callout-tap-swift
+}
+// #-end-code-snippet: navigation full-tutorial-swift
+

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -1,4 +1,3 @@
-// #-code-snippet: navigation full-tutorial-swift
 // #-code-snippet: navigation dependencies-swift
 import Mapbox
 import MapboxCoreNavigation
@@ -7,11 +6,7 @@ import MapboxDirections
 // #-end-code-snippet: navigation dependencies-swift
 
 class ViewController: UIViewController, MGLMapViewDelegate {
-    
-    // #-code-snippet: navigation mapview-var-swift
     var mapView: MGLMapView!
-    // #-end-code-snippet: navigation mapview-var-swift
-    
     // #-code-snippet: navigation directions-route-swift
     var directionsRoute: Route?
     // #-end-code-snippet: navigation directions-route-swift
@@ -30,9 +25,10 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         // #-code-snippet: navigation user-location-swift
         // Allow the map view to display the user's location
         mapView.showsUserLocation = true
-        // #-end-code-snippet: navigation user-location-swift
+        // #-end-code-snippet: navigation user-location
         
         // #-code-snippet: navigation gesture-recognizer-swift
+        // Add a gesture recognizer to the map view
         let setDestination = UILongPressGestureRecognizer(target: self, action: #selector(didLongPress(_:)))
         mapView.addGestureRecognizer(setDestination)
         // #-end-code-snippet: navigation gesture-recognizer-swift
@@ -59,14 +55,13 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         annotation.title = "Start navigation"
         mapView.addAnnotation(annotation)
         
-        // #-code-snippet: navigation call-calculate-route-swift
+        // Calcuate the route from the user's location to the set destination
         calculateRoute(from: (mapView.userLocation!.coordinate), to: annotation.coordinate) { [unowned self] (route, error) in
             if error != nil {
                 // Print an error message
                 print("Error calculating route")
             }
-        }
-        // #-end-code-snippet: navigation call-calculate-route-swift
+        }t
     }
     // #-end-code-snippet: navigation long-press-swift
     
@@ -77,14 +72,16 @@ class ViewController: UIViewController, MGLMapViewDelegate {
                         completion: @escaping (Route?, Error?) -> ()) {
         
         let origin = Waypoint(coordinate: origin, name: "Start")
-        
         let destination = Waypoint(coordinate: destination, name: "Finish")
         
+        // Specify that the route is intented for automobiles avoiding traffic
         let options = NavigationRouteOptions(waypoints: [origin, destination], profileIdentifier: .automobileAvoidingTraffic)
         
+        // Generate the route object and draw it on the map
         _ = Directions.shared.calculate(options) { (waypoints, routes, error) in
             guard let route = routes?.first else { return }
             self.directionsRoute = route
+            // Draw the route on the map after creating it
             self.drawRoute(route: self.directionsRoute!)
         }
     }
@@ -93,7 +90,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
     // #-code-snippet: navigation draw-route-swift
     func drawRoute(route: Route) {
         guard route.coordinateCount > 0 else { return }
-        // Convert the route’s coordinates into a polyline.
+        // Convert the route’s coordinates into a polyline
         var routeCoordinates = route.coordinates!
         let polyline = MGLPolylineFeature(coordinates: &routeCoordinates, count: route.coordinateCount)
         
@@ -102,56 +99,30 @@ class ViewController: UIViewController, MGLMapViewDelegate {
             source.shape = polyline
         } else {
             let source = MGLShapeSource(identifier: "route-source", features: [polyline], options: nil)
-            // #-code-snippet: navigation route-style-swift
+
+            // Customize the route line color and width
             let lineStyle = MGLLineStyleLayer(identifier: "route-style", source: source)
             lineStyle.lineColor = MGLStyleValue(rawValue:  #colorLiteral(red: 0.1897518039, green: 0.3010634184, blue: 0.7994888425, alpha: 1))
             lineStyle.lineWidth = MGLStyleValue(rawValue: 3)
-            // #-end-code-snippet: navigation route-style-swift
             
+            // Add the source and style layer of the route line to the map
             mapView.style?.addSource(source)
             mapView.style?.addLayer(lineStyle)
         }
     }
     // #-end-code-snippet: navigation draw-route-swift
     
-    // #-code-snippet: navigation present-navigation-swift
-    func presentNavigation(along route: Route) {
-        class CustomStyle: DayStyle {
-            
-            public required init() {
-                super.init()
-                mapStyleURL = URL(string: "mapbox://styles/mapbox/light-v9")!
-            }
-            
-            override func apply() {
-                super.apply()
-                ManeuverView.appearance().backgroundColor =  #colorLiteral(red: 0.1897518039, green: 0.3010634184, blue: 0.7994888425, alpha: 1)
-                RouteTableViewHeaderView.appearance().backgroundColor =  #colorLiteral(red: 0.1897518039, green: 0.3010634184, blue: 0.7994888425, alpha: 1)
-                Button.appearance().textColor = .white
-                WayNameLabel.appearance().textColor = .white
-                DistanceLabel.appearance().textColor = .white
-                DestinationLabel.appearance().textColor = .white
-                ArrivalTimeLabel.appearance().textColor = .white
-                TimeRemainingLabel.appearance().textColor = .white
-                DistanceRemainingLabel.appearance().textColor = .white
-                TurnArrowView.appearance().primaryColor = .white
-                TurnArrowView.appearance().secondaryColor = .white
-                LanesView.appearance().backgroundColor = .white
-                LaneArrowView.appearance().primaryColor = .white
-                CancelButton.appearance().tintColor = .white
-            }
-        }
-        
-        let viewController = NavigationViewController(for: route, styles: [CustomStyle()])
-        self.present(viewController, animated: true, completion: nil)
-    }
-    // #-end-code-snippet: navigation present-navigation-swift
-    
     // #-code-snippet: navigation callout-tap-swift
     func mapView(_ mapView: MGLMapView, tapOnCalloutFor annotation: MGLAnnotation) {
         self.presentNavigation(along: directionsRoute!)
     }
     // #-end-code-snippet: navigation callout-tap-swift
+    
+    // #-code-snippet: navigation tap-callout-swift
+    func mapView(_ mapView: MGLMapView, tapOnCalloutFor annotation: MGLAnnotation) {
+        let navigationViewController = NavigationViewController(for: directionsRoute!)
+        self.present(navigationViewController, animated: true, completion: nil)
+    }
+    // #-end-code-snippet: navigation tap-callout-swift
 }
-// #-end-code-snippet: navigation full-tutorial-swift
 

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -58,7 +58,6 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         // Calcuate the route from the user's location to the set destination
         calculateRoute(from: (mapView.userLocation!.coordinate), to: annotation.coordinate) { (route, error) in
             if error != nil {
-                // Print an error message
                 print("Error calculating route")
             }
         }

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -15,7 +15,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         super.viewDidLoad()
         
         // #-code-snippet: navigation init-map-swift
-        mapView = NavigationMapView(frame: view.bounds, styleURL: MGLStyle.streetsStyleURL())
+        mapView = NavigationMapView(frame: view.bounds)
         mapView.setCenter(CLLocationCoordinate2D(latitude: 30.265, longitude: -97.741), zoomLevel: 11, animated: false)
         view.addSubview(mapView)
         // Set the map view's delegate
@@ -61,7 +61,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
                 // Print an error message
                 print("Error calculating route")
             }
-        }t
+        }
     }
     // #-end-code-snippet: navigation long-press-swift
     
@@ -111,12 +111,6 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         }
     }
     // #-end-code-snippet: navigation draw-route-swift
-    
-    // #-code-snippet: navigation callout-tap-swift
-    func mapView(_ mapView: MGLMapView, tapOnCalloutFor annotation: MGLAnnotation) {
-        self.presentNavigation(along: directionsRoute!)
-    }
-    // #-end-code-snippet: navigation callout-tap-swift
     
     // #-code-snippet: navigation tap-callout-swift
     func mapView(_ mapView: MGLMapView, tapOnCalloutFor annotation: MGLAnnotation) {

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -80,8 +80,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         
         // Generate the route object and draw it on the map
         _ = Directions.shared.calculate(options) { (waypoints, routes, error) in
-            guard let route = routes?.first else { return }
-            self.directionsRoute = route
+            self.directionsRoute = routes?.first
             // Draw the route on the map after creating it
             self.drawRoute(route: self.directionsRoute!)
         }

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -102,7 +102,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
 
             // Customize the route line color and width
             let lineStyle = MGLLineStyleLayer(identifier: "route-style", source: source)
-            lineStyle.lineColor = MGLStyleValue(rawValue:  #colorLiteral(red: 0.1897518039, green: 0.3010634184, blue: 0.7994888425, alpha: 1))
+            lineStyle.lineColor = MGLStyleValue(rawValue: #colorLiteral(red: 0.1897518039, green: 0.3010634184, blue: 0.7994888425, alpha: 1))
             lineStyle.lineWidth = MGLStyleValue(rawValue: 3)
             
             // Add the source and style layer of the route line to the map

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -25,7 +25,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         // #-code-snippet: navigation user-location-swift
         // Allow the map view to display the user's location
         mapView.showsUserLocation = true
-        // #-end-code-snippet: navigation user-location
+        // #-end-code-snippet: navigation user-location-swift
         
         // #-code-snippet: navigation gesture-recognizer-swift
         // Add a gesture recognizer to the map view

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -78,7 +78,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         let options = NavigationRouteOptions(waypoints: [origin, destination], profileIdentifier: .automobileAvoidingTraffic)
         
         // Generate the route object and draw it on the map
-        _ = Directions.shared.calculate(options) { (waypoints, routes, error) in
+        _ = Directions.shared.calculate(options) { [unowned self] (waypoints, routes, error) in
             self.directionsRoute = routes?.first
             // Draw the route on the map after creating it
             self.drawRoute(route: self.directionsRoute!)

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -58,7 +58,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         // Calcuate the route from the user's location to the set destination
         calculateRoute(from: (mapView.userLocation!.coordinate), to: annotation.coordinate) { (route, error) in
             if error != nil {
-                NSLog("Error calculating route: \(String(describing: error))")
+                print("Error calculating route")
             }
         }
     }
@@ -78,7 +78,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         let options = NavigationRouteOptions(waypoints: [origin, destination], profileIdentifier: .automobileAvoidingTraffic)
         
         // Generate the route object and draw it on the map
-        Directions.shared.calculate(options) { (waypoints, routes, error) in
+        _ = Directions.shared.calculate(options) { (waypoints, routes, error) in
             self.directionsRoute = routes?.first
             // Draw the route on the map after creating it
             self.drawRoute(route: self.directionsRoute!)

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -58,7 +58,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         // Calcuate the route from the user's location to the set destination
         calculateRoute(from: (mapView.userLocation!.coordinate), to: annotation.coordinate) { (route, error) in
             if error != nil {
-                print("Error calculating route")
+                NSLog("Error calculating route: \(String(describing: error))")
             }
         }
     }

--- a/Examples.xcodeproj/project.pbxproj
+++ b/Examples.xcodeproj/project.pbxproj
@@ -1033,10 +1033,10 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-DocsCode/Pods-DocsCode-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/AWSCore/AWSCore.framework",
-				"${BUILT_PRODUCTS_DIR}/AWSPolly/AWSPolly.framework",
 				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework",
 				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework.dSYM",
+				"${BUILT_PRODUCTS_DIR}/AWSCore/AWSCore.framework",
+				"${BUILT_PRODUCTS_DIR}/AWSPolly/AWSPolly.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxCoreNavigation/MapboxCoreNavigation.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxDirections.swift/MapboxDirections.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxMobileEvents/MapboxMobileEvents.framework",
@@ -1049,10 +1049,10 @@
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSCore.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSPolly.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mapbox.framework",
 				"${DWARF_DSYM_FOLDER_PATH}/Mapbox.framework.dSYM",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSCore.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSPolly.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxCoreNavigation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxDirections.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxMobileEvents.framework",
@@ -1105,8 +1105,8 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Examples/Pods-Examples-frameworks.sh",
-				"${PODS_ROOT}/Mapbox-iOS-SDK-symbols/dynamic/Mapbox.framework",
-				"${PODS_ROOT}/Mapbox-iOS-SDK-symbols/dynamic/Mapbox.framework.dSYM",
+				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework",
+				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework.dSYM",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/Examples.xcodeproj/project.pbxproj
+++ b/Examples.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		0503374B1F7199DF007309B0 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 050337491F7199DF007309B0 /* LaunchScreen.storyboard */; };
 		055ABCC11EFB139C0063BACA /* FillPatternExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 055ABCC01EFB139C0063BACA /* FillPatternExample.m */; };
 		055ABCC31EFB14AE0063BACA /* FillPatternExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 055ABCC21EFB14AE0063BACA /* FillPatternExample.swift */; };
+		0587D7031F9A43D300209947 /* DDSCircleLayerTutorialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0587D7021F9A43D300209947 /* DDSCircleLayerTutorialViewController.swift */; };
+		0587D7061F9A466000209947 /* DDSCircleLayerTutorialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0587D7051F9A466000209947 /* DDSCircleLayerTutorialViewController.m */; };
 		05A868901F7314EF00242FB4 /* FirstStepsTutorialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 05A8688F1F7314EF00242FB4 /* FirstStepsTutorialViewController.m */; };
 		05DB802F1F75A4AD00F73326 /* DocsCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DB802E1F75A4AD00F73326 /* DocsCodeTests.swift */; };
 		079E77C51E1C4E2100F92FA8 /* camera.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 079E77C41E1C4E2100F92FA8 /* camera.xcassets */; };
@@ -170,6 +172,9 @@
 		055ABCBF1EFB139C0063BACA /* FillPatternExample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FillPatternExample.h; sourceTree = "<group>"; };
 		055ABCC01EFB139C0063BACA /* FillPatternExample.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FillPatternExample.m; sourceTree = "<group>"; };
 		055ABCC21EFB14AE0063BACA /* FillPatternExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FillPatternExample.swift; sourceTree = "<group>"; };
+		0587D7021F9A43D300209947 /* DDSCircleLayerTutorialViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDSCircleLayerTutorialViewController.swift; sourceTree = "<group>"; };
+		0587D7041F9A466000209947 /* DDSCircleLayerTutorialViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DDSCircleLayerTutorialViewController.h; sourceTree = "<group>"; };
+		0587D7051F9A466000209947 /* DDSCircleLayerTutorialViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DDSCircleLayerTutorialViewController.m; sourceTree = "<group>"; };
 		05A8688D1F7314EF00242FB4 /* DocsCode-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DocsCode-Bridging-Header.h"; sourceTree = "<group>"; };
 		05A8688E1F7314EF00242FB4 /* FirstStepsTutorialViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FirstStepsTutorialViewController.h; sourceTree = "<group>"; };
 		05A8688F1F7314EF00242FB4 /* FirstStepsTutorialViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FirstStepsTutorialViewController.m; sourceTree = "<group>"; };
@@ -392,6 +397,7 @@
 		0503373F1F7199DF007309B0 /* DocsCode */ = {
 			isa = PBXGroup;
 			children = (
+				0587D7011F9A435F00209947 /* DDSCircleLayerTutorial */,
 				05DB80361F75A87100F73326 /* FirstStepsTutorial */,
 				050337401F7199DF007309B0 /* AppDelegate.swift */,
 				050337441F7199DF007309B0 /* Main.storyboard */,
@@ -401,6 +407,16 @@
 				05A8688D1F7314EF00242FB4 /* DocsCode-Bridging-Header.h */,
 			);
 			path = DocsCode;
+			sourceTree = "<group>";
+		};
+		0587D7011F9A435F00209947 /* DDSCircleLayerTutorial */ = {
+			isa = PBXGroup;
+			children = (
+				0587D7021F9A43D300209947 /* DDSCircleLayerTutorialViewController.swift */,
+				0587D7041F9A466000209947 /* DDSCircleLayerTutorialViewController.h */,
+				0587D7051F9A466000209947 /* DDSCircleLayerTutorialViewController.m */,
+			);
+			path = DDSCircleLayerTutorial;
 			sourceTree = "<group>";
 		};
 		05DB802D1F75A4AD00F73326 /* DocsCodeTests */ = {
@@ -1157,8 +1173,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0587D7061F9A466000209947 /* DDSCircleLayerTutorialViewController.m in Sources */,
 				05A868901F7314EF00242FB4 /* FirstStepsTutorialViewController.m in Sources */,
 				050337431F7199DF007309B0 /* FirstStepsTutorialViewController.swift in Sources */,
+				0587D7031F9A43D300209947 /* DDSCircleLayerTutorialViewController.swift in Sources */,
 				050337411F7199DF007309B0 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples.xcodeproj/project.pbxproj
+++ b/Examples.xcodeproj/project.pbxproj
@@ -488,9 +488,6 @@
 				9682470E1C5BF12700494AB8 /* DrawingAMarkerExample.m */,
 				9682471F1C5C1C0400494AB8 /* DrawingAPolygonExample.m */,
 				3E085B821EC526E500163C99 /* ExtrusionsExample.m */,
-				3E22EF511F8821F800605203 /* ImageSourceExample.m */,
-				3E3FB66D1F0588B3004512C6 /* LightExample.m */,
-				3E3FB66F1F0589AD004512C6 /* PointHotspotExample.m */,
 				055ABCC01EFB139C0063BACA /* FillPatternExample.m */,
 				3E22EF511F8821F800605203 /* ImageSourceExample.m */,
 				3E3FB66D1F0588B3004512C6 /* LightExample.m */,
@@ -1414,6 +1411,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = DocsCode/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.DocsCode;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1433,6 +1431,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				INFOPLIST_FILE = DocsCode/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.DocsCode;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Examples.xcodeproj/project.pbxproj
+++ b/Examples.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		0587D7031F9A43D300209947 /* DDSCircleLayerTutorialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0587D7021F9A43D300209947 /* DDSCircleLayerTutorialViewController.swift */; };
 		0587D7061F9A466000209947 /* DDSCircleLayerTutorialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0587D7051F9A466000209947 /* DDSCircleLayerTutorialViewController.m */; };
 		05A868901F7314EF00242FB4 /* FirstStepsTutorialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 05A8688F1F7314EF00242FB4 /* FirstStepsTutorialViewController.m */; };
+		05AB82451FBC09AB005FB704 /* NavigationTutorialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05AB82441FBC09AB005FB704 /* NavigationTutorialViewController.swift */; };
+		05AB82481FBC0D41005FB704 /* NavigationTutorialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 05AB82471FBC0D41005FB704 /* NavigationTutorialViewController.m */; };
 		05DB802F1F75A4AD00F73326 /* DocsCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DB802E1F75A4AD00F73326 /* DocsCodeTests.swift */; };
 		079E77C51E1C4E2100F92FA8 /* camera.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 079E77C41E1C4E2100F92FA8 /* camera.xcassets */; };
 		07C138C01E6F646F00D6F678 /* ShapeCollectionFeatureExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 07C138BF1E6F646F00D6F678 /* ShapeCollectionFeatureExample.m */; };
@@ -178,6 +180,9 @@
 		05A8688D1F7314EF00242FB4 /* DocsCode-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "DocsCode-Bridging-Header.h"; sourceTree = "<group>"; };
 		05A8688E1F7314EF00242FB4 /* FirstStepsTutorialViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FirstStepsTutorialViewController.h; sourceTree = "<group>"; };
 		05A8688F1F7314EF00242FB4 /* FirstStepsTutorialViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FirstStepsTutorialViewController.m; sourceTree = "<group>"; };
+		05AB82441FBC09AB005FB704 /* NavigationTutorialViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationTutorialViewController.swift; sourceTree = "<group>"; };
+		05AB82461FBC0D41005FB704 /* NavigationTutorialViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NavigationTutorialViewController.h; sourceTree = "<group>"; };
+		05AB82471FBC0D41005FB704 /* NavigationTutorialViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NavigationTutorialViewController.m; sourceTree = "<group>"; };
 		05DB802C1F75A4AD00F73326 /* DocsCodeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DocsCodeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		05DB802E1F75A4AD00F73326 /* DocsCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocsCodeTests.swift; sourceTree = "<group>"; };
 		05DB80301F75A4AE00F73326 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -397,6 +402,7 @@
 		0503373F1F7199DF007309B0 /* DocsCode */ = {
 			isa = PBXGroup;
 			children = (
+				05AB82431FBC0988005FB704 /* NavigationTutorial */,
 				0587D7011F9A435F00209947 /* DDSCircleLayerTutorial */,
 				05DB80361F75A87100F73326 /* FirstStepsTutorial */,
 				050337401F7199DF007309B0 /* AppDelegate.swift */,
@@ -417,6 +423,16 @@
 				0587D7051F9A466000209947 /* DDSCircleLayerTutorialViewController.m */,
 			);
 			path = DDSCircleLayerTutorial;
+			sourceTree = "<group>";
+		};
+		05AB82431FBC0988005FB704 /* NavigationTutorial */ = {
+			isa = PBXGroup;
+			children = (
+				05AB82441FBC09AB005FB704 /* NavigationTutorialViewController.swift */,
+				05AB82461FBC0D41005FB704 /* NavigationTutorialViewController.h */,
+				05AB82471FBC0D41005FB704 /* NavigationTutorialViewController.m */,
+			);
+			path = NavigationTutorial;
 			sourceTree = "<group>";
 		};
 		05DB802D1F75A4AD00F73326 /* DocsCodeTests */ = {
@@ -1174,7 +1190,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				0587D7061F9A466000209947 /* DDSCircleLayerTutorialViewController.m in Sources */,
+				05AB82481FBC0D41005FB704 /* NavigationTutorialViewController.m in Sources */,
 				05A868901F7314EF00242FB4 /* FirstStepsTutorialViewController.m in Sources */,
+				05AB82451FBC09AB005FB704 /* NavigationTutorialViewController.swift in Sources */,
 				050337431F7199DF007309B0 /* FirstStepsTutorialViewController.swift in Sources */,
 				0587D7031F9A43D300209947 /* DDSCircleLayerTutorialViewController.swift in Sources */,
 				050337411F7199DF007309B0 /* AppDelegate.swift in Sources */,

--- a/Examples.xcodeproj/project.pbxproj
+++ b/Examples.xcodeproj/project.pbxproj
@@ -757,6 +757,7 @@
 				0503373A1F7199DF007309B0 /* Sources */,
 				0503373B1F7199DF007309B0 /* Frameworks */,
 				0503373C1F7199DF007309B0 /* Resources */,
+				056F105B1FC4C80A0037FFBE /* Insert Mapbox Access Token */,
 				467E4FA75B8B2FDD0E7B32DF /* [CP] Embed Pods Frameworks */,
 				10C0A307CAE7A1B5B741F127 /* [CP] Copy Pods Resources */,
 			);
@@ -966,6 +967,20 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		056F105B1FC4C80A0037FFBE /* Insert Mapbox Access Token */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Insert Mapbox Access Token";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "$SRCROOT/Examples/insert-mapbox-token.sh";
+		};
 		10C0A307CAE7A1B5B741F127 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1021,13 +1036,35 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-DocsCode/Pods-DocsCode-frameworks.sh",
-				"${PODS_ROOT}/Mapbox-iOS-SDK-symbols/dynamic/Mapbox.framework",
-				"${PODS_ROOT}/Mapbox-iOS-SDK-symbols/dynamic/Mapbox.framework.dSYM",
+				"${BUILT_PRODUCTS_DIR}/AWSCore/AWSCore.framework",
+				"${BUILT_PRODUCTS_DIR}/AWSPolly/AWSPolly.framework",
+				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework",
+				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework.dSYM",
+				"${BUILT_PRODUCTS_DIR}/MapboxCoreNavigation/MapboxCoreNavigation.framework",
+				"${BUILT_PRODUCTS_DIR}/MapboxDirections.swift/MapboxDirections.framework",
+				"${BUILT_PRODUCTS_DIR}/MapboxMobileEvents/MapboxMobileEvents.framework",
+				"${BUILT_PRODUCTS_DIR}/MapboxNavigation/MapboxNavigation.framework",
+				"${BUILT_PRODUCTS_DIR}/OSRMTextInstructions/OSRMTextInstructions.framework",
+				"${BUILT_PRODUCTS_DIR}/Polyline/Polyline.framework",
+				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
+				"${BUILT_PRODUCTS_DIR}/Solar/Solar.framework",
+				"${BUILT_PRODUCTS_DIR}/Turf/Turf.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSCore.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSPolly.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mapbox.framework",
 				"${DWARF_DSYM_FOLDER_PATH}/Mapbox.framework.dSYM",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxCoreNavigation.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxDirections.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxMobileEvents.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxNavigation.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OSRMTextInstructions.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Polyline.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Solar.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Turf.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '8.0'
+platform :ios, '9.0'
 use_frameworks!
 
 def shared_pods

--- a/Podfile
+++ b/Podfile
@@ -1,12 +1,8 @@
 platform :ios, '8.0'
 use_frameworks!
 
-def shared_pods
-  pod 'Mapbox-iOS-SDK-symbols', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.7.0/platform/ios/Mapbox-iOS-SDK-symbols.podspec'
-end
-
 target 'Examples' do
-  shared_pods
+  pod 'Mapbox-iOS-SDK', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.7.0/platform/ios/Mapbox-iOS-SDK.podspec'
 end
 
 target 'DocsCode' do

--- a/Podfile
+++ b/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '9.0'
+platform :ios, '8.0'
 use_frameworks!
 
 def shared_pods
@@ -10,7 +10,8 @@ target 'Examples' do
 end
 
 target 'DocsCode' do
-  shared_pods
+  platform :ios, '9.0'
+  pod 'MapboxNavigation', '~> 0.10'
 end
 
 target 'ExamplesTests' do

--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,8 @@ end
 
 target 'DocsCode' do
   platform :ios, '9.0'
-  pod 'MapboxNavigation', '~> 0.10'
+  pod 'MapboxCoreNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git'
+  pod 'MapboxNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :tag => 'v0.11.0-rc.1'
 end
 
 target 'ExamplesTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,6 @@ PODS:
   - AWSPolly (2.6.6):
     - AWSCore (= 2.6.6)
   - Mapbox-iOS-SDK (3.7.0)
-  - Mapbox-iOS-SDK-symbols (3.7.0-symbols)
   - MapboxCoreNavigation (0.11.0-rc.1):
     - MapboxDirections.swift (~> 0.12)
     - MapboxMobileEvents (~> 0.2)
@@ -29,13 +28,13 @@ PODS:
   - Turf (0.0.4)
 
 DEPENDENCIES:
-  - Mapbox-iOS-SDK-symbols (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.7.0/platform/ios/Mapbox-iOS-SDK-symbols.podspec`)
+  - Mapbox-iOS-SDK (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.7.0/platform/ios/Mapbox-iOS-SDK.podspec`)
   - MapboxCoreNavigation (from `https://github.com/mapbox/mapbox-navigation-ios.git`)
   - MapboxNavigation (from `https://github.com/mapbox/mapbox-navigation-ios.git`, tag `v0.11.0-rc.1`)
 
 EXTERNAL SOURCES:
-  Mapbox-iOS-SDK-symbols:
-    :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.7.0/platform/ios/Mapbox-iOS-SDK-symbols.podspec
+  Mapbox-iOS-SDK:
+    :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.7.0/platform/ios/Mapbox-iOS-SDK.podspec
   MapboxCoreNavigation:
     :git: https://github.com/mapbox/mapbox-navigation-ios.git
   MapboxNavigation:
@@ -54,7 +53,6 @@ SPEC CHECKSUMS:
   AWSCore: 64619e45b47678afab53ca0f9b4fa380ebee6f0b
   AWSPolly: 1491ed4d692befddded0af142f1258a209a4379b
   Mapbox-iOS-SDK: 699818d30e1ed4985d3efc6a06c40b90907c586d
-  Mapbox-iOS-SDK-symbols: 8697f210c63b81b85b792a80408a253076986f67
   MapboxCoreNavigation: b220024fa7398aa3e8580c3e4aba490ef75cd8a9
   MapboxDirections.swift: c6d75e3c8bff106332c55bc4dfe4f4f51ee84445
   MapboxMobileEvents: 9e48b59d0eed04508595dcb04a77b7632e1c3054
@@ -65,6 +63,6 @@ SPEC CHECKSUMS:
   Solar: 2dc6e7cc39186cb0c8228fa08df76fb50c7d8f24
   Turf: 6c169618fa671e3f8a7b764b5b3332053ad6110e
 
-PODFILE CHECKSUM: 54b820b7915174fb3b326e83de1b6a043f097950
+PODFILE CHECKSUM: bb1960711aea29e7f9c2479e5ce4f67b4619d604
 
 COCOAPODS: 1.3.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,56 @@
 PODS:
+  - AWSCore (2.6.5)
+  - AWSPolly (2.6.5):
+    - AWSCore (= 2.6.5)
+  - Mapbox-iOS-SDK (3.6.4)
   - Mapbox-iOS-SDK-symbols (3.7.0-symbols)
+  - MapboxCoreNavigation (0.10.0):
+    - MapboxDirections.swift (~> 0.12)
+    - MapboxMobileEvents (~> 0.2)
+    - OSRMTextInstructions (~> 0.5)
+    - Turf (~> 0.0.4)
+  - MapboxDirections.swift (0.12.1):
+    - Polyline (= 4.1.1)
+  - MapboxMobileEvents (0.2.10)
+  - MapboxNavigation (0.10.0):
+    - AWSPolly (~> 2.6)
+    - Mapbox-iOS-SDK (~> 3.6)
+    - MapboxCoreNavigation (= 0.10.0)
+    - SDWebImage (~> 4.1)
+    - Solar (= 2.0.0)
+    - Turf (~> 0.0.4)
+  - OSRMTextInstructions (0.5.0):
+    - MapboxDirections.swift (~> 0.10)
+  - Polyline (4.1.1)
+  - SDWebImage (4.2.2):
+    - SDWebImage/Core (= 4.2.2)
+  - SDWebImage/Core (4.2.2)
+  - Solar (2.0.0)
+  - Turf (0.0.4)
 
 DEPENDENCIES:
   - Mapbox-iOS-SDK-symbols (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.7.0/platform/ios/Mapbox-iOS-SDK-symbols.podspec`)
+  - MapboxNavigation (~> 0.10)
 
 EXTERNAL SOURCES:
   Mapbox-iOS-SDK-symbols:
     :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.7.0/platform/ios/Mapbox-iOS-SDK-symbols.podspec
 
 SPEC CHECKSUMS:
+  AWSCore: b4895b4a5256d0040f8825ad31f3477d081f508f
+  AWSPolly: ede618a621f07e1ff3512f2396f2ca96b57d357e
+  Mapbox-iOS-SDK: 47847dd44285477e0dfffd0130f65c8a52823ada
   Mapbox-iOS-SDK-symbols: 8697f210c63b81b85b792a80408a253076986f67
+  MapboxCoreNavigation: 2d398584e1cf3951258c2f464904797a6d3fc730
+  MapboxDirections.swift: b8d17a00440c050bbcc38c83523e558ee18e1054
+  MapboxMobileEvents: 9e48b59d0eed04508595dcb04a77b7632e1c3054
+  MapboxNavigation: c246a5e80673692b6d5bf714ab58b1f78602d3d0
+  OSRMTextInstructions: 7bbe5a1ba548991d2a7ffba38262845e7a024390
+  Polyline: 381d1e699fd12508f97cfc468478dfbab67edf1f
+  SDWebImage: 89a9d32cd520bbb46eb14e541d5109b3564af198
+  Solar: ea092f7660c1b58d2b754227decb61a1c6710826
+  Turf: 6c169618fa671e3f8a7b764b5b3332053ad6110e
 
-PODFILE CHECKSUM: eb69fcf89eb02d00e8a3e2a56a1c37d8d0b1ac2f
+PODFILE CHECKSUM: 6c3d9e5c68009bcb78acdffe621c10800b4b5e97
 
-COCOAPODS: 1.4.0.beta.2
+COCOAPODS: 1.3.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,56 +1,70 @@
 PODS:
-  - AWSCore (2.6.5)
-  - AWSPolly (2.6.5):
-    - AWSCore (= 2.6.5)
-  - Mapbox-iOS-SDK (3.6.4)
+  - AWSCore (2.6.6)
+  - AWSPolly (2.6.6):
+    - AWSCore (= 2.6.6)
+  - Mapbox-iOS-SDK (3.7.0)
   - Mapbox-iOS-SDK-symbols (3.7.0-symbols)
-  - MapboxCoreNavigation (0.10.0):
+  - MapboxCoreNavigation (0.11.0-rc.1):
     - MapboxDirections.swift (~> 0.12)
     - MapboxMobileEvents (~> 0.2)
     - OSRMTextInstructions (~> 0.5)
     - Turf (~> 0.0.4)
-  - MapboxDirections.swift (0.12.1):
-    - Polyline (= 4.1.1)
+  - MapboxDirections.swift (0.13.0):
+    - Polyline (~> 4.2)
   - MapboxMobileEvents (0.2.10)
-  - MapboxNavigation (0.10.0):
+  - MapboxNavigation (0.11.0-rc.1):
     - AWSPolly (~> 2.6)
     - Mapbox-iOS-SDK (~> 3.6)
-    - MapboxCoreNavigation (= 0.10.0)
+    - MapboxCoreNavigation (= 0.11.0-rc.1)
     - SDWebImage (~> 4.1)
-    - Solar (= 2.0.0)
+    - Solar (~> 2.1)
     - Turf (~> 0.0.4)
-  - OSRMTextInstructions (0.5.0):
-    - MapboxDirections.swift (~> 0.10)
-  - Polyline (4.1.1)
+  - OSRMTextInstructions (0.6.0):
+    - MapboxDirections.swift (~> 0.13)
+  - Polyline (4.2.0)
   - SDWebImage (4.2.2):
     - SDWebImage/Core (= 4.2.2)
   - SDWebImage/Core (4.2.2)
-  - Solar (2.0.0)
+  - Solar (2.1.0)
   - Turf (0.0.4)
 
 DEPENDENCIES:
   - Mapbox-iOS-SDK-symbols (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.7.0/platform/ios/Mapbox-iOS-SDK-symbols.podspec`)
-  - MapboxNavigation (~> 0.10)
+  - MapboxCoreNavigation (from `https://github.com/mapbox/mapbox-navigation-ios.git`)
+  - MapboxNavigation (from `https://github.com/mapbox/mapbox-navigation-ios.git`, tag `v0.11.0-rc.1`)
 
 EXTERNAL SOURCES:
   Mapbox-iOS-SDK-symbols:
     :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.7.0/platform/ios/Mapbox-iOS-SDK-symbols.podspec
+  MapboxCoreNavigation:
+    :git: https://github.com/mapbox/mapbox-navigation-ios.git
+  MapboxNavigation:
+    :git: https://github.com/mapbox/mapbox-navigation-ios.git
+    :tag: v0.11.0-rc.1
+
+CHECKOUT OPTIONS:
+  MapboxCoreNavigation:
+    :commit: 8d42b8586fa31c35b48f7b11a52a42c80ccf32b0
+    :git: https://github.com/mapbox/mapbox-navigation-ios.git
+  MapboxNavigation:
+    :git: https://github.com/mapbox/mapbox-navigation-ios.git
+    :tag: v0.11.0-rc.1
 
 SPEC CHECKSUMS:
-  AWSCore: b4895b4a5256d0040f8825ad31f3477d081f508f
-  AWSPolly: ede618a621f07e1ff3512f2396f2ca96b57d357e
-  Mapbox-iOS-SDK: 47847dd44285477e0dfffd0130f65c8a52823ada
+  AWSCore: 64619e45b47678afab53ca0f9b4fa380ebee6f0b
+  AWSPolly: 1491ed4d692befddded0af142f1258a209a4379b
+  Mapbox-iOS-SDK: 699818d30e1ed4985d3efc6a06c40b90907c586d
   Mapbox-iOS-SDK-symbols: 8697f210c63b81b85b792a80408a253076986f67
-  MapboxCoreNavigation: 2d398584e1cf3951258c2f464904797a6d3fc730
-  MapboxDirections.swift: b8d17a00440c050bbcc38c83523e558ee18e1054
+  MapboxCoreNavigation: b220024fa7398aa3e8580c3e4aba490ef75cd8a9
+  MapboxDirections.swift: c6d75e3c8bff106332c55bc4dfe4f4f51ee84445
   MapboxMobileEvents: 9e48b59d0eed04508595dcb04a77b7632e1c3054
-  MapboxNavigation: c246a5e80673692b6d5bf714ab58b1f78602d3d0
-  OSRMTextInstructions: 7bbe5a1ba548991d2a7ffba38262845e7a024390
-  Polyline: 381d1e699fd12508f97cfc468478dfbab67edf1f
+  MapboxNavigation: 8bb827f73dec9340ffab877e70e458404db91298
+  OSRMTextInstructions: 7abc90eaf50ff1f7333c526daf360f6a2f1ea059
+  Polyline: 3d69f75bb136357e27291d439d0436c6ebda57a4
   SDWebImage: 89a9d32cd520bbb46eb14e541d5109b3564af198
-  Solar: ea092f7660c1b58d2b754227decb61a1c6710826
+  Solar: 2dc6e7cc39186cb0c8228fa08df76fb50c7d8f24
   Turf: 6c169618fa671e3f8a7b764b5b3332053ad6110e
 
-PODFILE CHECKSUM: 6c3d9e5c68009bcb78acdffe621c10800b4b5e97
+PODFILE CHECKSUM: 54b820b7915174fb3b326e83de1b6a043f097950
 
 COCOAPODS: 1.3.1


### PR DESCRIPTION
Adds the code used for iOS tutorials from [mapbox.com/help/tutorials](mapbox.com/help/tutorials/) into the DocsCode target. This will be used for testing code snippets before being used in documentation on [mapbox.com/help](mapbox.com/help).