### PR TITLE
Clarify comment on custom style example

### DIFF
--- a/Examples/ObjectiveC/CustomStyleExample.m
+++ b/Examples/ObjectiveC/CustomStyleExample.m
@@ -8,8 +8,8 @@ NSString *const MBXExampleCustomStyle = @"CustomStyleExample";
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-    // Fill in the next line with your style URL from Mapbox Studio.
-    // <#mapbox://styles/userName/styleHash#>
+    // Replace the string in the URL below with your custom style URL from Mapbox Studio.
+    // Read more about style URLs here: https://www.mapbox.com/help/define-style-url/
     NSURL *styleURL = [NSURL URLWithString:@"mapbox://styles/mapbox/outdoors-v9"];
     MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds
                                                    styleURL:styleURL];

--- a/Examples/Swift/CustomStyleExample.swift
+++ b/Examples/Swift/CustomStyleExample.swift
@@ -6,8 +6,8 @@ class CustomStyleExample_Swift: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        // Fill in the next line with your style URL from Mapbox Studio.
-        // <#mapbox://styles/userName/styleHash#>
+        // Replace the string in the URL below with your custom style URL from Mapbox Studio
+        // Read more about style URLs here: https://www.mapbox.com/help/define-style-url/
         let styleURL = URL(string: "mapbox://styles/mapbox/outdoors-v9")
         let mapView = MGLMapView(frame: view.bounds,
                                  styleURL: styleURL)

--- a/Examples/Swift/CustomStyleExample.swift
+++ b/Examples/Swift/CustomStyleExample.swift
@@ -6,7 +6,7 @@ class CustomStyleExample_Swift: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        // Replace the string in the URL below with your custom style URL from Mapbox Studio
+        // Replace the string in the URL below with your custom style URL from Mapbox Studio.
         // Read more about style URLs here: https://www.mapbox.com/help/define-style-url/
         let styleURL = URL(string: "mapbox://styles/mapbox/outdoors-v9")
         let mapView = MGLMapView(frame: view.bounds,


### PR DESCRIPTION
Adds a link to the documentation for [obtaining style URLs](https://www.mapbox.com/help/define-style-url/) in the custom style example.