### PR TITLE
Navigation tutorial edits

### DIFF
--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
@@ -9,47 +9,35 @@
 
 @interface NavigationTutorialViewController () <MGLMapViewDelegate>
 
+// #-code-snippet: navigation vc-variables-objc
 @property (nonatomic) MBNavigationMapView *mapView;
-// #-code-snippet: navigation directions-route-objc
 @property (nonatomic) MBRoute *directionsRoute;
-// #-end-code-snippet: navigation directions-route-objc
-
+// #-end-code-snippet: navigation vc-variables-objc
 
 @end
 
 @implementation NavigationTutorialViewController
 
+// #-code-snippet: navigation view-did-load-objc
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    // #-code-snippet: navigation init-map-objc
+
     self.mapView = [[MBNavigationMapView alloc] initWithFrame:self.view.bounds];
 
-    [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(30.265, -97.741)
-                            zoomLevel:11 animated:NO];
     [self.view addSubview:self.mapView];
     // Set the map view's delegate
     self.mapView.delegate = self;
-    // #-end-code-snippet: navigation init-map-objc
-    
-    // #-code-snippet: navigation user-location-objc
+
     // Allow the map view to display the user's location
     self.mapView.showsUserLocation = YES;
-    // #-end-code-snippet: navigation user-location-objc
+    [self.mapView setUserTrackingMode:MGLUserTrackingModeFollow animated:YES];
     
-    // #-code-snippet: navigation gesture-recognizer-objc
     // Add a gesture recognizer to the map view
     UILongPressGestureRecognizer *setDestination = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(didLongPress:)];
     [self.mapView addGestureRecognizer:setDestination];
-    // #-end-code-snippet: navigation gesture-recognizer-objc
 }
-
-// #-code-snippet: navigation allow-callouts-objc
-// Implement the delegate method that allows annotations to show callouts when tapped
--(BOOL)mapView:(MGLMapView *)mapView annotationCanShowCallout:(id<MGLAnnotation>)annotation {
-    return true;
-}
-// #-end-code-snippet: navigation allow-callouts-objc
+// #-end-code-snippet: navigation view-did-load-objc
 
 // #-code-snippet: navigation long-press-objc
 -(void)didLongPress:(UITapGestureRecognizer *)sender {
@@ -67,7 +55,7 @@
     annotation.title = @"Start navigtation";
     [self.mapView addAnnotation:annotation];
     
-    // Calcuate the route from the user's location to the set destination
+    // Calculate the route from the user's location to the set destination
     [self calculateRoutefromOrigin:self.mapView.userLocation.coordinate
                      toDestination:annotation.coordinate
                         completion:^(MBRoute * _Nullable route, NSError * _Nullable error) {
@@ -88,7 +76,7 @@
     
     MBWaypoint *destinationWaypoint = [[MBWaypoint alloc] initWithCoordinate:destination coordinateAccuracy:-1 name:@"Finish"];
     
-    // Specify that the route is intented for automobiles avoiding traffic
+    // Specify that the route is intended for automobiles avoiding traffic
     MBNavigationRouteOptions *options = [[MBNavigationRouteOptions alloc] initWithWaypoints:@[originWaypoint, destinationWaypoint] profileIdentifier:MBDirectionsProfileIdentifierAutomobileAvoidingTraffic];
     
     // Generate the route object and draw it on the map
@@ -136,15 +124,20 @@
         [self.mapView.style addSource:source];
         [self.mapView.style addLayer:lineStyle];
     }
-    
 }
 // #-end-code-snippet: navigation draw-route-objc
 
-// #-code-snippet: navigation tap-callout-objc
+// #-code-snippet: navigation callout-functions-objc
+// Implement the delegate method that allows annotations to show callouts when tapped
+-(BOOL)mapView:(MGLMapView *)mapView annotationCanShowCallout:(id<MGLAnnotation>)annotation {
+    return true;
+}
+
+// Present the navigation view controller when the callout is selected
 -(void)mapView:(MGLMapView *)mapView tapOnCalloutForAnnotation:(id<MGLAnnotation>)annotation {
     MBNavigationViewController *navigationViewController = [[MBNavigationViewController alloc] initWithRoute:_directionsRoute directions:[MBDirections sharedDirections] style:nil locationManager:nil];
     [self presentViewController:navigationViewController animated:YES completion:nil];
 }
-// #-end-code-snippet: navigation tap-callout-objc
+// #-end-code-snippet: navigation callout-functions-objc
 
 @end

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -7,7 +7,7 @@ import MapboxDirections
 
 class ViewController: UIViewController, MGLMapViewDelegate {
     // #-code-snippet: navigation vc-variables-swift
-    var mapView: MGLMapView!
+    var mapView: NavigationMapView!
     var directionsRoute: Route?
     // #-end-code-snippet: navigation vc-variables-swift
     

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -6,40 +6,31 @@ import MapboxDirections
 // #-end-code-snippet: navigation dependencies-swift
 
 class ViewController: UIViewController, MGLMapViewDelegate {
+    // #-code-snippet: navigation vc-variables-swift
     var mapView: MGLMapView!
-    // #-code-snippet: navigation directions-route-swift
     var directionsRoute: Route?
-    // #-end-code-snippet: navigation directions-route-swift
+    // #-end-code-snippet: navigation vc-variables-swift
     
+    // #-code-snippet: navigation view-did-load-swift
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        // #-code-snippet: navigation init-map-swift
         mapView = NavigationMapView(frame: view.bounds)
-        mapView.setCenter(CLLocationCoordinate2D(latitude: 30.265, longitude: -97.741), zoomLevel: 11, animated: false)
+
         view.addSubview(mapView)
+        
         // Set the map view's delegate
         mapView.delegate = self
-        // #-end-code-snippet: navigation init-map-swift
         
-        // #-code-snippet: navigation user-location-swift
-        // Allow the map view to display the user's location
+        // Allow the map to display the user's location
         mapView.showsUserLocation = true
-        // #-end-code-snippet: navigation user-location-swift
+        mapView.setUserTrackingMode(.follow, animated: true)
         
-        // #-code-snippet: navigation gesture-recognizer-swift
         // Add a gesture recognizer to the map view
         let setDestination = UILongPressGestureRecognizer(target: self, action: #selector(didLongPress(_:)))
         mapView.addGestureRecognizer(setDestination)
-        // #-end-code-snippet: navigation gesture-recognizer-swift
     }
-    
-    // #-code-snippet: navigation allow-callouts-swift
-    // Implement the delegate method that allows annotations to show callouts when tapped
-    func mapView(_ mapView: MGLMapView, annotationCanShowCallout annotation: MGLAnnotation) -> Bool {
-        return true
-    }
-    // #-end-code-snippet: navigation allow-callouts-swift
+    // #-end-code-snippet: navigation view-did-load-swift
     
     // #-code-snippet: navigation long-press-swift
     @objc func didLongPress(_ sender: UILongPressGestureRecognizer) {
@@ -54,8 +45,8 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         annotation.coordinate = coordinate
         annotation.title = "Start navigation"
         mapView.addAnnotation(annotation)
-        
-        // Calcuate the route from the user's location to the set destination
+
+        // Calculate the route from the user's location to the set destination
         calculateRoute(from: (mapView.userLocation!.coordinate), to: annotation.coordinate) { (route, error) in
             if error != nil {
                 print("Error calculating route")
@@ -74,7 +65,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         let origin = Waypoint(coordinate: origin, coordinateAccuracy: -1, name: "Start")
         let destination = Waypoint(coordinate: destination, coordinateAccuracy: -1, name: "Finish")
         
-        // Specify that the route is intented for automobiles avoiding traffic
+        // Specify that the route is intended for automobiles avoiding traffic
         let options = NavigationRouteOptions(waypoints: [origin, destination], profileIdentifier: .automobileAvoidingTraffic)
         
         // Generate the route object and draw it on the map
@@ -111,11 +102,17 @@ class ViewController: UIViewController, MGLMapViewDelegate {
     }
     // #-end-code-snippet: navigation draw-route-swift
     
-    // #-code-snippet: navigation tap-callout-swift
+    // #-code-snippet: navigation callout-functions-swift
+    // Implement the delegate method that allows annotations to show callouts when tapped
+    func mapView(_ mapView: MGLMapView, annotationCanShowCallout annotation: MGLAnnotation) -> Bool {
+        return true
+    }
+    
+    // Present the navigation view controller when the callout is selected
     func mapView(_ mapView: MGLMapView, tapOnCalloutFor annotation: MGLAnnotation) {
         let navigationViewController = NavigationViewController(for: directionsRoute!)
         self.present(navigationViewController, animated: true, completion: nil)
     }
-    // #-end-code-snippet: navigation tap-callout-swift
+    // #-end-code-snippet: navigation callout-functions-swift
 }
 

--- a/Podfile
+++ b/Podfile
@@ -7,8 +7,7 @@ end
 
 target 'DocsCode' do
   platform :ios, '9.0'
-  pod 'MapboxCoreNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git'
-  pod 'MapboxNavigation', :git => 'https://github.com/mapbox/mapbox-navigation-ios.git', :tag => 'v0.11.0-rc.1'
+  pod 'MapboxNavigation', '~> 0.11'
 end
 
 target 'ExamplesTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - AWSCore (2.6.6)
-  - AWSPolly (2.6.6):
-    - AWSCore (= 2.6.6)
+  - AWSCore (2.6.7)
+  - AWSPolly (2.6.7):
+    - AWSCore (= 2.6.7)
   - Mapbox-iOS-SDK (3.7.0)
-  - MapboxCoreNavigation (0.11.0-rc.1):
+  - MapboxCoreNavigation (0.11.0):
     - MapboxDirections.swift (~> 0.12)
     - MapboxMobileEvents (~> 0.2)
     - OSRMTextInstructions (~> 0.5)
@@ -11,10 +11,10 @@ PODS:
   - MapboxDirections.swift (0.13.0):
     - Polyline (~> 4.2)
   - MapboxMobileEvents (0.2.10)
-  - MapboxNavigation (0.11.0-rc.1):
+  - MapboxNavigation (0.11.0):
     - AWSPolly (~> 2.6)
     - Mapbox-iOS-SDK (~> 3.6)
-    - MapboxCoreNavigation (= 0.11.0-rc.1)
+    - MapboxCoreNavigation (= 0.11.0)
     - SDWebImage (~> 4.1)
     - Solar (~> 2.1)
     - Turf (~> 0.0.4)
@@ -29,40 +29,26 @@ PODS:
 
 DEPENDENCIES:
   - Mapbox-iOS-SDK (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.7.0/platform/ios/Mapbox-iOS-SDK.podspec`)
-  - MapboxCoreNavigation (from `https://github.com/mapbox/mapbox-navigation-ios.git`)
-  - MapboxNavigation (from `https://github.com/mapbox/mapbox-navigation-ios.git`, tag `v0.11.0-rc.1`)
+  - MapboxNavigation (~> 0.11)
 
 EXTERNAL SOURCES:
   Mapbox-iOS-SDK:
     :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.7.0/platform/ios/Mapbox-iOS-SDK.podspec
-  MapboxCoreNavigation:
-    :git: https://github.com/mapbox/mapbox-navigation-ios.git
-  MapboxNavigation:
-    :git: https://github.com/mapbox/mapbox-navigation-ios.git
-    :tag: v0.11.0-rc.1
-
-CHECKOUT OPTIONS:
-  MapboxCoreNavigation:
-    :commit: 8d42b8586fa31c35b48f7b11a52a42c80ccf32b0
-    :git: https://github.com/mapbox/mapbox-navigation-ios.git
-  MapboxNavigation:
-    :git: https://github.com/mapbox/mapbox-navigation-ios.git
-    :tag: v0.11.0-rc.1
 
 SPEC CHECKSUMS:
-  AWSCore: 64619e45b47678afab53ca0f9b4fa380ebee6f0b
-  AWSPolly: 1491ed4d692befddded0af142f1258a209a4379b
+  AWSCore: a5ff5fb202342b922eb9036af9ecc3bc28a032eb
+  AWSPolly: 63caad839a8134c8903938f1b40ac73678000c9b
   Mapbox-iOS-SDK: 699818d30e1ed4985d3efc6a06c40b90907c586d
-  MapboxCoreNavigation: b220024fa7398aa3e8580c3e4aba490ef75cd8a9
+  MapboxCoreNavigation: 613bfae2879d0fe88ae1ffbdc7170a2ef2961f4e
   MapboxDirections.swift: c6d75e3c8bff106332c55bc4dfe4f4f51ee84445
   MapboxMobileEvents: 9e48b59d0eed04508595dcb04a77b7632e1c3054
-  MapboxNavigation: 8bb827f73dec9340ffab877e70e458404db91298
+  MapboxNavigation: f349a1bdedc9ad88a9e7906fabc252d24331b918
   OSRMTextInstructions: 7abc90eaf50ff1f7333c526daf360f6a2f1ea059
   Polyline: 3d69f75bb136357e27291d439d0436c6ebda57a4
   SDWebImage: 89a9d32cd520bbb46eb14e541d5109b3564af198
   Solar: 2dc6e7cc39186cb0c8228fa08df76fb50c7d8f24
   Turf: 6c169618fa671e3f8a7b764b5b3332053ad6110e
 
-PODFILE CHECKSUM: bb1960711aea29e7f9c2479e5ce4f67b4619d604
+PODFILE CHECKSUM: b56579f2d3331a6cc80668b815ff6322f9b72b13
 
 COCOAPODS: 1.3.1


### PR DESCRIPTION
This PR edits some of the code comments in the code for the [navigation tutorial](https://www.mapbox.com/help/ios-navigation-sdk/).

It also switches `mapView.userTrackingMode` to `mapView.setCenter` and corrects a spelling error or two.