### PR TITLE
Add Navigation Hello World example

### DIFF
--- a/Examples.xcodeproj/project.pbxproj
+++ b/Examples.xcodeproj/project.pbxproj
@@ -118,6 +118,8 @@
 		96D432061C84B9CF007D09D1 /* pisavector.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 96D432051C84B9CF007D09D1 /* pisavector.xcassets */; };
 		ABDAFB44FD9859A9FE77424E /* Pods_DocsCode.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EF6577E027F75C7D93ED70A6 /* Pods_DocsCode.framework */; };
 		BBD05676206B24335DEA52C4 /* Pods_ExamplesUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7692D1D792EB3849E8754E6B /* Pods_ExamplesUITests.framework */; };
+		C565167F1FE18FAC00A0AD18 /* NavigationExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = C565167E1FE18FAC00A0AD18 /* NavigationExample.swift */; };
+		C56516811FE1971E00A0AD18 /* NavigationExample.m in Sources */ = {isa = PBXBuildFile; fileRef = C56516801FE1971E00A0AD18 /* NavigationExample.m */; };
 		DD5939E41E6639BA0009BEB2 /* ClusteringExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD5939E31E6639BA0009BEB2 /* ClusteringExample.swift */; };
 		DD5939E61E6778480009BEB2 /* clustering.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DD5939E51E6778480009BEB2 /* clustering.xcassets */; };
 		DDF943291E5DE63300545D0F /* ClusteringExample.m in Sources */ = {isa = PBXBuildFile; fileRef = DDF943281E5DE63300545D0F /* ClusteringExample.m */; };
@@ -346,6 +348,9 @@
 		9A1ECC25B13FE3249B26BE0A /* Pods-Shared-DocsCode.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shared-DocsCode.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Shared-DocsCode/Pods-Shared-DocsCode.debug.xcconfig"; sourceTree = "<group>"; };
 		9EC12D8F1A97963D68BFA871 /* Pods_Examples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Examples.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C057E98F506AAA58F0473788 /* Pods-Shared-Examples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shared-Examples.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Shared-Examples/Pods-Shared-Examples.debug.xcconfig"; sourceTree = "<group>"; };
+		C565167E1FE18FAC00A0AD18 /* NavigationExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NavigationExample.swift; sourceTree = "<group>"; };
+		C56516801FE1971E00A0AD18 /* NavigationExample.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NavigationExample.m; sourceTree = "<group>"; };
+		C56516821FE1973800A0AD18 /* NavigationExample.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NavigationExample.h; sourceTree = "<group>"; };
 		DD5939E31E6639BA0009BEB2 /* ClusteringExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClusteringExample.swift; sourceTree = "<group>"; };
 		DD5939E51E6778480009BEB2 /* clustering.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = clustering.xcassets; sourceTree = "<group>"; };
 		DDF943271E5DE63300545D0F /* ClusteringExample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ClusteringExample.h; sourceTree = "<group>"; };
@@ -493,19 +498,20 @@
 				3E3FB66D1F0588B3004512C6 /* LightExample.m */,
 				3E52ACD21EE8D8AF0056242C /* LiveDataExample.m */,
 				3EA5AA011FAD2E95007073C0 /* MapSnapshotterExample.m */,
+				C56516801FE1971E00A0AD18 /* NavigationExample.m */,
 				96115A671CAD4E1C000963B8 /* OfflinePackExample.m */,
 				3E3FB66F1F0589AD004512C6 /* PointHotspotExample.m */,
 				646B62A31DEF7115000AA523 /* RuntimeAddLineExample.m */,
 				646B62A51DEF7121000AA523 /* RuntimeAnimateLineExample.m */,
 				646B62BC1DEF965A000AA523 /* RuntimeCircleStylesExample.m */,
-				646B629B1DEF6DF1000AA523 /* RuntimeToggleLayerExample.m */,
 				64BBDAFC1DF24DEB00BB705D /* RuntimeMultipleAnnotationsExample.m */,
+				646B629B1DEF6DF1000AA523 /* RuntimeToggleLayerExample.m */,
 				968247071C5BEBDC00494AB8 /* SatelliteStyleExample.m */,
 				64BBDAF71DF2330B00BB705D /* SelectFeatureExample.m */,
 				07C138BF1E6F646F00D6F678 /* ShapeCollectionFeatureExample.m */,
 				9691AAA61C5AAD8F006A58C6 /* SimpleMapViewExample.m */,
-				64CF970B1DF224C500C3C27B /* SourceCustomVectorExample.m */,
 				64CF97161DF2251500C3C27B /* SourceCustomRasterExample.m */,
+				64CF970B1DF224C500C3C27B /* SourceCustomVectorExample.m */,
 				969E7FDC1D25C31700663F84 /* UserTrackingModesExample.m */,
 			);
 			name = "Objective-C";
@@ -541,20 +547,21 @@
 				3E3FB66A1F05888E004512C6 /* LightExample.swift */,
 				3E52ACD41EE8D94A0056242C /* LiveDataExample.swift */,
 				3EA5AA031FAD2EC7007073C0 /* MapSnapshotterExample.swift */,
+				C565167E1FE18FAC00A0AD18 /* NavigationExample.swift */,
 				3EBCD7111DC28240001E342F /* OfflinePackExample.swift */,
 				3EBCD7121DC28240001E342F /* PointConversionExample.swift */,
 				3EC11D261EA84091001AAAB8 /* PointHotspotExample.swift */,
 				646B62AD1DEF7155000AA523 /* RuntimeAddLineExample.swift */,
 				646B62AF1DEF7161000AA523 /* RuntimeAnimateLineExample.swift */,
 				646B62B31DEF9613000AA523 /* RuntimeCircleStylesExample.swift */,
-				646B62961DEF6DAF000AA523 /* RuntimeToggleLayerExample.swift */,
 				64BBDB021DF24E0900BB705D /* RuntimeMultipleAnnotationsExample.swift */,
+				646B62961DEF6DAF000AA523 /* RuntimeToggleLayerExample.swift */,
 				3EBCD7131DC28240001E342F /* SatelliteStyleExample.swift */,
 				64BBDAF51DF232FD00BB705D /* SelectFeatureExample.swift */,
 				07C138C11E6F65D000D6F678 /* ShapeCollectionFeatureExample.swift */,
 				3EBCD7141DC28240001E342F /* SimpleMapViewExample.swift */,
-				64CF970F1DF224E400C3C27B /* SourceCustomVectorExample.swift */,
 				64CF97111DF224F600C3C27B /* SourceCustomRasterExample.swift */,
+				64CF970F1DF224E400C3C27B /* SourceCustomVectorExample.swift */,
 				3EBCD7151DC28240001E342F /* UserTrackingModesExample.swift */,
 			);
 			name = Swift;
@@ -656,8 +663,8 @@
 		9682472D1C5C226D00494AB8 /* Headers */ = {
 			isa = PBXGroup;
 			children = (
-				07F53B861E00D08600B58DB3 /* AnnotationViewMultipleExample.h */,
 				962B450D1D1C8520007B7454 /* AnnotationViewExample.h */,
+				07F53B861E00D08600B58DB3 /* AnnotationViewMultipleExample.h */,
 				1F1F84731E538ABB00332CC3 /* BlockingGesturesDelegateExample.h */,
 				968247111C5C0F0F00494AB8 /* CalloutDelegateUsageExample.h */,
 				968247251C5C1DC700494AB8 /* CameraAnimationExample.h */,
@@ -682,20 +689,21 @@
 				3E3FB66C1F0588B3004512C6 /* LightExample.h */,
 				3E52ACD11EE8D8AF0056242C /* LiveDataExample.h */,
 				3EA5AA001FAD2E95007073C0 /* MapSnapshotterExample.h */,
+				C56516821FE1973800A0AD18 /* NavigationExample.h */,
 				96115A661CAD4E1C000963B8 /* OfflinePackExample.h */,
 				968247281C5C1FF800494AB8 /* PointConversionExample.h */,
 				3EC11D231EA8405A001AAAB8 /* PointHotspotExample.h */,
 				646B62A21DEF7106000AA523 /* RuntimeAddLineExample.h */,
 				646B62A11DEF70DD000AA523 /* RuntimeAnimateLineExample.h */,
 				646B62BB1DEF964A000AA523 /* RuntimeCircleStylesExample.h */,
-				646B629E1DEF6DFD000AA523 /* RuntimeToggleLayerExample.h */,
 				64BBDAFB1DF24DD700BB705D /* RuntimeMultipleAnnotationsExample.h */,
+				646B629E1DEF6DFD000AA523 /* RuntimeToggleLayerExample.h */,
 				968247061C5BEBDC00494AB8 /* SatelliteStyleExample.h */,
 				64BBDAFA1DF2331600BB705D /* SelectFeatureExample.h */,
 				07C138BE1E6F646F00D6F678 /* ShapeCollectionFeatureExample.h */,
 				9691AAA51C5AAD8F006A58C6 /* SimpleMapViewExample.h */,
-				64CF970E1DF224D400C3C27B /* SourceCustomVectorExample.h */,
 				64CF97191DF2252C00C3C27B /* SourceCustomRasterExample.h */,
+				64CF970E1DF224D400C3C27B /* SourceCustomVectorExample.h */,
 				969E7FDB1D25C31700663F84 /* UserTrackingModesExample.h */,
 			);
 			name = Headers;
@@ -1033,10 +1041,10 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-DocsCode/Pods-DocsCode-frameworks.sh",
-				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework",
-				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework.dSYM",
 				"${BUILT_PRODUCTS_DIR}/AWSCore/AWSCore.framework",
 				"${BUILT_PRODUCTS_DIR}/AWSPolly/AWSPolly.framework",
+				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework",
+				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework.dSYM",
 				"${BUILT_PRODUCTS_DIR}/MapboxCoreNavigation/MapboxCoreNavigation.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxDirections.swift/MapboxDirections.framework",
 				"${BUILT_PRODUCTS_DIR}/MapboxMobileEvents/MapboxMobileEvents.framework",
@@ -1049,10 +1057,10 @@
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mapbox.framework",
-				"${DWARF_DSYM_FOLDER_PATH}/Mapbox.framework.dSYM",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSCore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSPolly.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mapbox.framework",
+				"${DWARF_DSYM_FOLDER_PATH}/Mapbox.framework.dSYM",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxCoreNavigation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxDirections.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxMobileEvents.framework",
@@ -1105,13 +1113,35 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Examples/Pods-Examples-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/AWSCore/AWSCore.framework",
+				"${BUILT_PRODUCTS_DIR}/AWSPolly/AWSPolly.framework",
 				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework",
 				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework.dSYM",
+				"${BUILT_PRODUCTS_DIR}/MapboxCoreNavigation/MapboxCoreNavigation.framework",
+				"${BUILT_PRODUCTS_DIR}/MapboxDirections.swift/MapboxDirections.framework",
+				"${BUILT_PRODUCTS_DIR}/MapboxMobileEvents/MapboxMobileEvents.framework",
+				"${BUILT_PRODUCTS_DIR}/MapboxNavigation/MapboxNavigation.framework",
+				"${BUILT_PRODUCTS_DIR}/OSRMTextInstructions/OSRMTextInstructions.framework",
+				"${BUILT_PRODUCTS_DIR}/Polyline/Polyline.framework",
+				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
+				"${BUILT_PRODUCTS_DIR}/Solar/Solar.framework",
+				"${BUILT_PRODUCTS_DIR}/Turf/Turf.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSCore.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSPolly.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mapbox.framework",
 				"${DWARF_DSYM_FOLDER_PATH}/Mapbox.framework.dSYM",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxCoreNavigation.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxDirections.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxMobileEvents.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxNavigation.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OSRMTextInstructions.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Polyline.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Solar.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Turf.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1273,6 +1303,7 @@
 				3EBCD7261DC28240001E342F /* PointConversionExample.swift in Sources */,
 				961962D21C5821A9002D3DAB /* ExamplesTableViewController.m in Sources */,
 				64BBDB031DF24E0900BB705D /* RuntimeMultipleAnnotationsExample.swift in Sources */,
+				C56516811FE1971E00A0AD18 /* NavigationExample.m in Sources */,
 				3E52ACD51EE8D94A0056242C /* LiveDataExample.swift in Sources */,
 				646B62971DEF6DAF000AA523 /* RuntimeToggleLayerExample.swift in Sources */,
 				968247201C5C1C0400494AB8 /* DrawingAPolygonExample.m in Sources */,
@@ -1309,6 +1340,7 @@
 				964CB5111E42A0A3004549EA /* AnnotationViewMultipleExample.swift in Sources */,
 				3EC11D271EA84091001AAAB8 /* PointHotspotExample.swift in Sources */,
 				9691AAA81C5AAD8F006A58C6 /* DefaultStylesExample.m in Sources */,
+				C565167F1FE18FAC00A0AD18 /* NavigationExample.swift in Sources */,
 				64CF97101DF224E400C3C27B /* SourceCustomVectorExample.swift in Sources */,
 				3EBCD7211DC28240001E342F /* DrawingACustomMarkerExample.swift in Sources */,
 				3EBCD71E1DC28240001E342F /* CustomStyleExample.swift in Sources */,
@@ -1533,7 +1565,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -1579,7 +1611,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";

--- a/Examples/Examples.h
+++ b/Examples/Examples.h
@@ -43,6 +43,7 @@ extern NSString *const MBXExampleLight;
 extern NSString *const MBXExampleFillPattern;
 extern NSString *const MBXExampleLiveData;
 extern NSString *const MBXExampleMapSnapshotter;
+extern NSString *const MBExampleNavigation;
 extern NSString *const MBXExampleOfflinePack;
 extern NSString *const MBXExamplePointConversion;
 extern NSString *const MBXExamplePointHotspot;

--- a/Examples/Examples.m
+++ b/Examples/Examples.m
@@ -37,6 +37,7 @@
         MBXExampleImageSource,
         MBXExampleLight,
         MBXExampleMapSnapshotter,
+        MBExampleNavigation,
         MBXExampleLiveData,
         MBXExampleOfflinePack,
         MBXExamplePointConversion,

--- a/Examples/Info.plist
+++ b/Examples/Info.plist
@@ -47,5 +47,9 @@
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 </dict>
 </plist>

--- a/Examples/ObjectiveC/NavigationExample.h
+++ b/Examples/ObjectiveC/NavigationExample.h
@@ -1,0 +1,14 @@
+//
+//  NavigationExample.h
+//  Examples
+//
+//  Created by Bobby Sudekum on 12/13/17.
+//  Copyright © 2017 Mapbox. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface NavigationExample : UIViewController
+
+@end
+

--- a/Examples/ObjectiveC/NavigationExample.m
+++ b/Examples/ObjectiveC/NavigationExample.m
@@ -1,0 +1,7 @@
+#import "NavigationExample.h"
+@import Mapbox;
+
+NSString *const MBExampleNavigation = @"NavigationExample";
+
+@interface NavigationExample () <MGLMapViewDelegate>
+@end

--- a/Examples/Swift/NavigationExample.swift
+++ b/Examples/Swift/NavigationExample.swift
@@ -1,0 +1,25 @@
+import Foundation
+import MapboxCoreNavigation
+import MapboxNavigation
+import MapboxDirections
+
+@objc(NavigationExample_Swift)
+
+class NavigationExample: UIViewController {
+    
+    override func viewDidLoad() {
+        let origin = CLLocationCoordinate2DMake(37.77440680146262, -122.43539772352648)
+        let destination = CLLocationCoordinate2DMake(37.76556957793795, -122.42409811526268)
+        let options = NavigationRouteOptions(coordinates: [origin, destination])
+        
+        Directions.shared.calculate(options) { (waypoints, routes, error) in
+            guard let route = routes?.first, error == nil else {
+                print(error!.localizedDescription)
+                return
+            }
+            
+            let navigationController = NavigationViewController(for: route)
+            self.present(navigationController, animated: true, completion: nil)
+        }
+    }
+}

--- a/Podfile
+++ b/Podfile
@@ -1,12 +1,12 @@
-platform :ios, '8.0'
+platform :ios, '9.0'
 use_frameworks!
 
 target 'Examples' do
   pod 'Mapbox-iOS-SDK', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.7.1/platform/ios/Mapbox-iOS-SDK.podspec'
+  pod 'MapboxNavigation', '~> 0.11'
 end
 
 target 'DocsCode' do
-  platform :ios, '9.0'
   pod 'MapboxNavigation', '~> 0.11'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - AWSCore (2.6.7)
-  - AWSPolly (2.6.7):
-    - AWSCore (= 2.6.7)
+  - AWSCore (2.6.8)
+  - AWSPolly (2.6.8):
+    - AWSCore (= 2.6.8)
   - Mapbox-iOS-SDK (3.7.1)
   - MapboxCoreNavigation (0.11.0):
     - MapboxDirections.swift (~> 0.12)
     - MapboxMobileEvents (~> 0.2)
     - OSRMTextInstructions (~> 0.5)
     - Turf (~> 0.0.4)
-  - MapboxDirections.swift (0.15.0):
+  - MapboxDirections.swift (0.15.1):
     - Polyline (~> 4.2)
   - MapboxMobileEvents (0.2.10)
   - MapboxNavigation (0.11.0):
@@ -36,11 +36,11 @@ EXTERNAL SOURCES:
     :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v3.7.1/platform/ios/Mapbox-iOS-SDK.podspec
 
 SPEC CHECKSUMS:
-  AWSCore: a5ff5fb202342b922eb9036af9ecc3bc28a032eb
-  AWSPolly: 63caad839a8134c8903938f1b40ac73678000c9b
+  AWSCore: 35fca7c45f37f5ffc4ddf75f7aa943f3588d9227
+  AWSPolly: 148465388711b257c25918f4307f5a3727ff6fbc
   Mapbox-iOS-SDK: 34c96bec48a1122ead238e7e886cd9d613e6280c
   MapboxCoreNavigation: 613bfae2879d0fe88ae1ffbdc7170a2ef2961f4e
-  MapboxDirections.swift: ac6bb693d8d393fbc3f9b00615875cc99bb92153
+  MapboxDirections.swift: 2ed0a698a7721b5373362b74579c7194cda12528
   MapboxMobileEvents: 9e48b59d0eed04508595dcb04a77b7632e1c3054
   MapboxNavigation: f349a1bdedc9ad88a9e7906fabc252d24331b918
   OSRMTextInstructions: 7abc90eaf50ff1f7333c526daf360f6a2f1ea059
@@ -49,6 +49,6 @@ SPEC CHECKSUMS:
   Solar: 2dc6e7cc39186cb0c8228fa08df76fb50c7d8f24
   Turf: 6c169618fa671e3f8a7b764b5b3332053ad6110e
 
-PODFILE CHECKSUM: d650631bc24e69bbd525b970328d6f2bde359597
+PODFILE CHECKSUM: 63050831d2db855f4e81dea5133847376dae0922
 
-COCOAPODS: 1.2.1
+COCOAPODS: 1.3.1


### PR DESCRIPTION
This adds a simple hello world example in Swift. There were a couple of semi-invasive changes:

- Changing the min deployment target from 8 -> 9.
- added UIBackgroundModes to the plist

Per a conversation yesterday, while we work on putting together a site similar to `mapbox.com/ios-sdk/`, we thought this would be a good home.

I still need to create an objc example along with this, but I thought I'd get the conversation going on this change first.

/cc @friedbunny @captainbarbosa @ericrwolfe @colleenmcginnis 