### PR TITLE
Update third party vector source example

### DIFF
--- a/Examples/Files/third_party_vector_style.json
+++ b/Examples/Files/third_party_vector_style.json
@@ -4,7 +4,7 @@
         "mapillary": {
             "type": "vector",
             "tiles": ["https://d25uarhxywzl1j.cloudfront.net/v0.1/{z}/{x}/{y}.mvt"],
-            "attribution": "Mapillary, CC BY"
+            "attribution": "<a href=\"https://www.mapillary.com\" target=\"_blank\">© Mapillary, CC BY</a>"
         }
     },
     "layers": [{

--- a/Examples/Files/third_party_vector_style.json
+++ b/Examples/Files/third_party_vector_style.json
@@ -1,25 +1,25 @@
 {
     "version": 8,
     "sources": {
-	"osm": {
+	"mapillary": {
 	    "type": "vector",
-	    "tiles": ["https://vector.mapzen.com/osm/all/{z}/{x}/{y}.mvt?api_key=vector-tiles-LM25tq4"]
+	    "tiles": ["https://d25uarhxywzl1j.cloudfront.net/v0.1/{z}/{x}/{y}.mvt"]
 	}
     },
     "layers": [{
 	   "id": "background",
 	   "type": "background",
 	   "paint": {
-	       "background-color": "#41afa5"
+	       "background-color": "#485E77"
 	    }
 	}, {
-	   "id": "water",
-	   "type": "fill",
-	   "source": "osm",
-	   "source-layer": "water",
-	   "filter": ["==", "$type", "Polygon"],
+	   "id": "mapillary-sequences",
+	   "type": "line",
+	   "source": "mapillary",
+	   "source-layer": "mapillary-sequences",
+	   "filter": ["==", "$type", "LineString"],
 	   "paint": {
-	   "fill-color": "#3887be"
+	   "line-color": "#F56745"
 	}
     }]
 }

--- a/Examples/Files/third_party_vector_style.json
+++ b/Examples/Files/third_party_vector_style.json
@@ -1,26 +1,27 @@
 {
     "version": 8,
     "sources": {
-	"mapillary": {
-	    "type": "vector",
-	    "tiles": ["https://d25uarhxywzl1j.cloudfront.net/v0.1/{z}/{x}/{y}.mvt"],
-        "attribution": "Mapillary, CC BY"
-	}
+        "mapillary": {
+            "type": "vector",
+            "tiles": ["https://d25uarhxywzl1j.cloudfront.net/v0.1/{z}/{x}/{y}.mvt"],
+            "attribution": "Mapillary, CC BY"
+        }
     },
     "layers": [{
-	   "id": "background",
-	   "type": "background",
-	   "paint": {
-	       "background-color": "#485E77"
-	    }
-	}, {
-	   "id": "mapillary-sequences",
-	   "type": "line",
-	   "source": "mapillary",
-	   "source-layer": "mapillary-sequences",
-	   "filter": ["==", "$type", "LineString"],
-	   "paint": {
-	   "line-color": "#F56745"
-	}
-    }]
+               "id": "background",
+               "type": "background",
+               "paint": {
+               "background-color": "#485E77"
+               }
+               }, {
+               "id": "mapillary-sequences",
+               "type": "line",
+               "source": "mapillary",
+               "source-layer": "mapillary-sequences",
+               "filter": ["==", "$type", "LineString"],
+               "paint": {
+               "line-color": "#F56745"
+               }
+               }]
 }
+

--- a/Examples/Files/third_party_vector_style.json
+++ b/Examples/Files/third_party_vector_style.json
@@ -3,7 +3,8 @@
     "sources": {
 	"mapillary": {
 	    "type": "vector",
-	    "tiles": ["https://d25uarhxywzl1j.cloudfront.net/v0.1/{z}/{x}/{y}.mvt"]
+	    "tiles": ["https://d25uarhxywzl1j.cloudfront.net/v0.1/{z}/{x}/{y}.mvt"],
+        "attribution": "Mapillary, CC BY"
 	}
     },
     "layers": [{

--- a/Examples/ObjectiveC/ThirdPartyVectorStyleExample.m
+++ b/Examples/ObjectiveC/ThirdPartyVectorStyleExample.m
@@ -14,7 +14,7 @@ NSString *const MBXExampleThirdPartyVectorStyle = @"ThirdPartyVectorStyleExample
     NSURL *customStyleURL = [[NSBundle mainBundle] URLForResource:@"third_party_vector_style" withExtension:@"json"];
 
     MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:customStyleURL];
-    [mapView setCenterCoordinate:CLLocationCoordinate2DMake(37.28, -122.44) zoomLevel:11.5 animated:NO];
+    [mapView setCenterCoordinate:CLLocationCoordinate2DMake(60.16, 24.93) zoomLevel:12 animated:NO];
     mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     mapView.tintColor = [UIColor whiteColor];
 

--- a/Examples/ObjectiveC/ThirdPartyVectorStyleExample.m
+++ b/Examples/ObjectiveC/ThirdPartyVectorStyleExample.m
@@ -10,11 +10,11 @@ NSString *const MBXExampleThirdPartyVectorStyle = @"ThirdPartyVectorStyleExample
 
     // Third party vector tile sources can be added.
     
-    // In this case we're using custom style JSON (https://www.mapbox.com/mapbox-gl-style-spec/) to add a third party tile source: <https://vector.mapzen.com/osm/all/{z}/{x}/{y}.mvt>
+    // In this case we're using custom style JSON (https://www.mapbox.com/mapbox-gl-style-spec/) to add a third party tile source from Mapillary: <https://d25uarhxywzl1j.cloudfront.net/v0.1/{z}/{x}/{y}.mvt>
     NSURL *customStyleURL = [[NSBundle mainBundle] URLForResource:@"third_party_vector_style" withExtension:@"json"];
 
     MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:customStyleURL];
-
+    [mapView setCenterCoordinate:CLLocationCoordinate2DMake(37.28, -122.44) zoomLevel:11.5 animated:NO];
     mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     mapView.tintColor = [UIColor whiteColor];
 

--- a/Examples/Swift/ThirdPartyVectorStyleExample.swift
+++ b/Examples/Swift/ThirdPartyVectorStyleExample.swift
@@ -14,7 +14,7 @@ class ThirdPartyVectorStyleExample_Swift: UIViewController {
         let customStyleURL = Bundle.main.url(forResource: "third_party_vector_style", withExtension: "json")!
 
         mapView = MGLMapView(frame: view.bounds, styleURL: customStyleURL)
-        mapView.setCenter(CLLocationCoordinate2DMake(37.78, -122.44), zoomLevel: 11.5, animated: false)
+        mapView.setCenter(CLLocationCoordinate2DMake(60.16, 24.93), zoomLevel: 12, animated: false)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.tintColor = .white
         

--- a/Examples/Swift/ThirdPartyVectorStyleExample.swift
+++ b/Examples/Swift/ThirdPartyVectorStyleExample.swift
@@ -10,11 +10,11 @@ class ThirdPartyVectorStyleExample_Swift: UIViewController {
 
         // Third party vector tile sources can be added.
         
-        // In this case we're using custom style JSON (https://www.mapbox.com/mapbox-gl-style-spec/) to add a third party tile source: <https://vector.mapzen.com/osm/all/{z}/{x}/{y}.mvt>
+        // In this case we're using custom style JSON (https://www.mapbox.com/mapbox-gl-style-spec/) to add a third party tile source from Mapillary: <https://d25uarhxywzl1j.cloudfront.net/v0.1/{z}/{x}/{y}.mvt>
         let customStyleURL = Bundle.main.url(forResource: "third_party_vector_style", withExtension: "json")!
 
         mapView = MGLMapView(frame: view.bounds, styleURL: customStyleURL)
-
+        mapView.setCenter(CLLocationCoordinate2DMake(37.78, -122.44), zoomLevel: 11.5, animated: false)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.tintColor = .white
         


### PR DESCRIPTION
Updates the third party vector source example to use Mapillary tiles instead of Mapzen tiles.

<img width="801" alt="screenshot 2018-01-17 21 21 08" src="https://user-images.githubusercontent.com/10850812/35077650-5ad8f9c6-fbcc-11e7-89c2-b45ec99e023a.png">
