### PR TITLE
DraggableAnnotationView: add haptic feedback

### DIFF
--- a/Examples/ObjectiveC/DraggableAnnotationViewExample.m
+++ b/Examples/ObjectiveC/DraggableAnnotationViewExample.m
@@ -6,6 +6,12 @@ NSString *const MBXExampleDraggableAnnotationView = @"DraggableAnnotationViewExa
 // MGLAnnotationView subclass
 @interface DraggableAnnotationView : MGLAnnotationView
 @end
+
+// Private interface for DraggableAnnotationView
+@interface DraggableAnnotationView ()
+@property (nonatomic, nullable) UIImpactFeedbackGenerator *hapticFeedback;
+@end
+
 @implementation DraggableAnnotationView
 
 - (instancetype)initWithReuseIdentifier:(nullable NSString *)reuseIdentifier size:(CGFloat)size {
@@ -63,6 +69,15 @@ NSString *const MBXExampleDraggableAnnotationView = @"DraggableAnnotationViewExa
         self.layer.opacity = 0.8;
         self.transform = CGAffineTransformScale(CGAffineTransformIdentity, 1.5, 1.5);
     } completion:nil];
+
+    // Initialize haptic feedback generator and give the user a light thud.
+    if (@available(iOS 10.0, *)) {
+        self.hapticFeedback = [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleLight];
+        [self.hapticFeedback impactOccurred];
+
+        // Keep the generator prepared, as the drop feedback event will probably happen quite soon.
+        [self.hapticFeedback prepare];
+    }
 }
 
 - (void)endDragging {
@@ -71,6 +86,12 @@ NSString *const MBXExampleDraggableAnnotationView = @"DraggableAnnotationViewExa
         self.layer.opacity = 1;
         self.transform = CGAffineTransformScale(CGAffineTransformIdentity, 1, 1);
     } completion:nil];
+
+    // Give the user more haptic feedback when they drop the annotation, then release the current generator.
+    if (@available(iOS 10.0, *)) {
+        [self.hapticFeedback impactOccurred];
+        self.hapticFeedback = nil;
+    }
 }
 
 @end
@@ -97,7 +118,7 @@ NSString *const MBXExampleDraggableAnnotationView = @"DraggableAnnotationViewExa
     CLLocationCoordinate2D coordinates[] = {
         CLLocationCoordinate2DMake(0, -70),
         CLLocationCoordinate2DMake(0, -35),
-        CLLocationCoordinate2DMake(0,  0),
+        CLLocationCoordinate2DMake(0, 0),
         CLLocationCoordinate2DMake(0, 35),
         CLLocationCoordinate2DMake(0, 70),
     };

--- a/Examples/Swift/DraggableAnnotationViewExample.swift
+++ b/Examples/Swift/DraggableAnnotationViewExample.swift
@@ -19,7 +19,7 @@ class DraggableAnnotationViewExample_Swift: UIViewController, MGLMapViewDelegate
         let coordinates = [
             CLLocationCoordinate2D(latitude: 0, longitude: -70),
             CLLocationCoordinate2D(latitude: 0, longitude: -35),
-            CLLocationCoordinate2D(latitude: 0,  longitude: 0),
+            CLLocationCoordinate2D(latitude: 0, longitude: 0),
             CLLocationCoordinate2D(latitude: 0, longitude: 35),
             CLLocationCoordinate2D(latitude: 0, longitude: 70)
         ]
@@ -115,6 +115,12 @@ class DraggableAnnotationView: MGLAnnotationView {
             self.layer.opacity = 0.8
             self.transform = CGAffineTransform.identity.scaledBy(x: 1.5, y: 1.5)
         }, completion: nil)
+
+        // Initialize haptic feedback generator and give the user a light thud.
+        if #available(iOS 10.0, *) {
+            let hapticFeedback = UIImpactFeedbackGenerator(style: .light)
+            hapticFeedback.impactOccurred()
+        }
     }
     
     func endDragging() {
@@ -123,5 +129,11 @@ class DraggableAnnotationView: MGLAnnotationView {
             self.layer.opacity = 1
             self.transform = CGAffineTransform.identity.scaledBy(x: 1, y: 1)
         }, completion: nil)
+
+        // Give the user more haptic feedback when they drop the annotation.
+        if #available(iOS 10.0, *) {
+            let hapticFeedback = UIImpactFeedbackGenerator(style: .light)
+            hapticFeedback.impactOccurred()
+        }
     }
 }


### PR DESCRIPTION
Adds haptic feedback to the drag-and-drop annotations example.

Caveat: ObjC lets us declare properties with potentially unavailable classes and then check availability before initialization, but Swift does not. So, the Swift version can’t follow Apple’s suggested best practice of reusing the feedback generator (but the ObjC version can and does).

More about feedback generators can be found [at Apple’s docs](https://developer.apple.com/documentation/uikit/uifeedbackgenerator).

/cc @captainbarbosa @jmkiley @1ec5 