### PR TITLE
AnimatedLineExample: delay animation until map truly finishes loading

### DIFF
--- a/Examples/ObjectiveC/AnimatedLineExample.m
+++ b/Examples/ObjectiveC/AnimatedLineExample.m
@@ -32,15 +32,15 @@ NSString *const MBXExampleAnimatedLine = @"AnimatedLineExample";
 }
 
 // Wait until the map is loaded before adding to the map.
-- (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {
-    [self addLayer];
+- (void)mapViewDidFinishLoadingMap:(MGLMapView *)mapView {
+    [self addPolylineToStyle:mapView.style];
     [self animatePolyline];
 }
 
-- (void)addLayer {
+- (void)addPolylineToStyle:(MGLStyle *)style {
     // Add an empty MGLShapeSource, we’ll keep a reference to this and add points to this later.
     MGLShapeSource *source = [[MGLShapeSource alloc] initWithIdentifier:@"polyline" features:@[] options:nil];
-    [self.mapView.style addSource:source];
+    [style addSource:source];
     self.polylineSource = source;
     
     // Add a layer to style our polyline.

--- a/Examples/Swift/AnimatedLineExample.swift
+++ b/Examples/Swift/AnimatedLineExample.swift
@@ -27,12 +27,12 @@ class AnimatedLineExample_Swift: UIViewController, MGLMapViewDelegate {
     }
 
     // Wait until the map is loaded before adding to the map.
-    func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
-        addLayer(to: style)
+    func mapViewDidFinishLoadingMap(_ mapView: MGLMapView) {
+        addPolyline(to: mapView.style!)
         animatePolyline()
     }
 
-    func addLayer(to style: MGLStyle) {
+    func addPolyline(to style: MGLStyle) {
         // Add an empty MGLShapeSource, we’ll keep a reference to this and add points to this later.
         let source = MGLShapeSource(identifier: "polyline", shape: nil, options: nil)
         style.addSource(source)


### PR DESCRIPTION
Switches from using `mapView:didFinishLoadingStyle:` to `mapViewDidFinishLoadingMap:`, the latter of which fires when the map is visually loaded (as opposed to when the style object is ready to manipulate).

/cc @lilykaiser 