### PR TITLE
Navigation SDK v0.17.0-beta.1

### DIFF
--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
@@ -117,7 +117,7 @@
         
         // Customize the route line color and width
         lineStyle.lineColor = [NSExpression expressionForConstantValue:[UIColor blueColor]];
-        lineStyle.lineWidth = [NSExpression expressionForConstantValue:@"3"];
+        lineStyle.lineWidth = [NSExpression expressionForConstantValue:@3];
         
         // Add the source and style layer of the route line to the map
         [self.mapView.style addSource:source];

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
@@ -22,25 +22,24 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-
     self.mapView = [[MBNavigationMapView alloc] initWithFrame:self.view.bounds];
-
+    
     [self.view addSubview:self.mapView];
     // Set the map view's delegate
     self.mapView.delegate = self;
-
+    
     // Allow the map view to display the user's location
     self.mapView.showsUserLocation = YES;
     [self.mapView setUserTrackingMode:MGLUserTrackingModeFollow animated:YES];
     
     // Add a gesture recognizer to the map view
-    UILongPressGestureRecognizer *setDestination = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(didLongPress:)];
-    [self.mapView addGestureRecognizer:setDestination];
+    UILongPressGestureRecognizer *longPress = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(didLongPress:)];
+    [self.mapView addGestureRecognizer:longPress];
 }
 // #-end-code-snippet: navigation view-did-load-objc
 
 // #-code-snippet: navigation long-press-objc
--(void)didLongPress:(UITapGestureRecognizer *)sender {
+- (void)didLongPress:(UITapGestureRecognizer *)sender {
     if (sender.state != UIGestureRecognizerStateEnded) {
         return;
     }
@@ -52,24 +51,24 @@
     // Create a basic point annotation and add it to the map
     MGLPointAnnotation *annotation = [MGLPointAnnotation alloc];
     annotation.coordinate = coordinate;
-    annotation.title = @"Start navigtation";
+    annotation.title = @"Start navigation";
     [self.mapView addAnnotation:annotation];
     
     // Calculate the route from the user's location to the set destination
     [self calculateRoutefromOrigin:self.mapView.userLocation.coordinate
                      toDestination:annotation.coordinate
                         completion:^(MBRoute * _Nullable route, NSError * _Nullable error) {
-                            if (error != nil) {
-                                NSLog(@"Error calculating route: %@", error);
-                            }
+        if (error != nil) {
+            NSLog(@"Error calculating route: %@", error);
+        }
     }];
 }
 // #-end-code-snippet: navigation long-press-objc
 
 // #-code-snippet: navigation calculate-route-objc
--(void)calculateRoutefromOrigin:(CLLocationCoordinate2D)origin
-                  toDestination:(CLLocationCoordinate2D)destination
-                     completion:(void(^)(MBRoute *_Nullable route, NSError *_Nullable error))completion {
+- (void)calculateRoutefromOrigin:(CLLocationCoordinate2D)origin
+                   toDestination:(CLLocationCoordinate2D)destination
+                      completion:(void(^)(MBRoute *_Nullable route, NSError *_Nullable error))completion {
     
     // Coordinate accuracy is the maximum distance away from the waypoint that the route may still be considered viable, measured in meters. Negative values indicate that a indefinite number of meters away from the route and still be considered viable.
     MBWaypoint *originWaypoint = [[MBWaypoint alloc] initWithCoordinate:origin coordinateAccuracy:-1 name:@"Start"];
@@ -100,7 +99,7 @@
 // #-end-code-snippet: navigation calculate-route-objc
 
 // #-code-snippet: navigation draw-route-objc
--(void)drawRoute:(CLLocationCoordinate2D *)route {
+- (void)drawRoute:(CLLocationCoordinate2D *)route {
     if (self.directionsRoute.coordinateCount == 0) {
         return;
     }
@@ -110,7 +109,7 @@
     
     if ([self.mapView.style sourceWithIdentifier:@"route-source"]) {
         // If there's already a route line on the map, reset its shape to the new route
-        MGLShapeSource *source = [self.mapView.style sourceWithIdentifier:@"route-source"];
+        MGLShapeSource *source = (MGLShapeSource *)[self.mapView.style sourceWithIdentifier:@"route-source"];
         source.shape = polyline;
     } else {
         MGLShapeSource *source = [[MGLShapeSource alloc] initWithIdentifier:@"route-source" shape:polyline options:nil];
@@ -129,13 +128,13 @@
 
 // #-code-snippet: navigation callout-functions-objc
 // Implement the delegate method that allows annotations to show callouts when tapped
--(BOOL)mapView:(MGLMapView *)mapView annotationCanShowCallout:(id<MGLAnnotation>)annotation {
+- (BOOL)mapView:(MGLMapView *)mapView annotationCanShowCallout:(id<MGLAnnotation>)annotation {
     return true;
 }
 
 // Present the navigation view controller when the callout is selected
--(void)mapView:(MGLMapView *)mapView tapOnCalloutForAnnotation:(id<MGLAnnotation>)annotation {
-    MBNavigationViewController *navigationViewController = [[MBNavigationViewController alloc] initWithRoute:_directionsRoute directions:[MBDirections sharedDirections] style:nil locationManager:nil];
+- (void)mapView:(MGLMapView *)mapView tapOnCalloutForAnnotation:(id<MGLAnnotation>)annotation {
+    MBNavigationViewController *navigationViewController = [[MBNavigationViewController alloc] initWithRoute:self.directionsRoute directions:[MBDirections sharedDirections] style:nil locationManager:nil];
     [self presentViewController:navigationViewController animated:YES completion:nil];
 }
 // #-end-code-snippet: navigation callout-functions-objc

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -16,7 +16,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         super.viewDidLoad()
         
         mapView = NavigationMapView(frame: view.bounds)
-
+        
         view.addSubview(mapView)
         
         // Set the map view's delegate
@@ -27,8 +27,8 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         mapView.setUserTrackingMode(.follow, animated: true)
         
         // Add a gesture recognizer to the map view
-        let setDestination = UILongPressGestureRecognizer(target: self, action: #selector(didLongPress(_:)))
-        mapView.addGestureRecognizer(setDestination)
+        let longPress = UILongPressGestureRecognizer(target: self, action: #selector(didLongPress(_:)))
+        mapView.addGestureRecognizer(longPress)
     }
     // #-end-code-snippet: navigation view-did-load-swift
     
@@ -45,7 +45,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
         annotation.coordinate = coordinate
         annotation.title = "Start navigation"
         mapView.addAnnotation(annotation)
-
+        
         // Calculate the route from the user's location to the set destination
         calculateRoute(from: (mapView.userLocation!.coordinate), to: annotation.coordinate) { (route, error) in
             if error != nil {
@@ -89,7 +89,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
             source.shape = polyline
         } else {
             let source = MGLShapeSource(identifier: "route-source", features: [polyline], options: nil)
-
+            
             // Customize the route line color and width
             let lineStyle = MGLLineStyleLayer(identifier: "route-style", source: source)
             lineStyle.lineColor = MGLStyleValue(rawValue: #colorLiteral(red: 0.1897518039, green: 0.3010634184, blue: 0.7994888425, alpha: 1))

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -92,8 +92,8 @@ class ViewController: UIViewController, MGLMapViewDelegate {
             
             // Customize the route line color and width
             let lineStyle = MGLLineStyleLayer(identifier: "route-style", source: source)
-            lineStyle.lineColor = MGLStyleValue(rawValue: #colorLiteral(red: 0.1897518039, green: 0.3010634184, blue: 0.7994888425, alpha: 1))
-            lineStyle.lineWidth = MGLStyleValue(rawValue: 3)
+            lineStyle.lineColor = NSExpression(forConstantValue: #colorLiteral(red: 0.1897518039, green: 0.3010634184, blue: 0.7994888425, alpha: 1))
+            lineStyle.lineWidth = NSExpression(forConstantValue: 3)
             
             // Add the source and style layer of the route line to the map
             mapView.style?.addSource(source)

--- a/Examples.xcodeproj/project.pbxproj
+++ b/Examples.xcodeproj/project.pbxproj
@@ -121,6 +121,8 @@
 		96D432061C84B9CF007D09D1 /* pisavector.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 96D432051C84B9CF007D09D1 /* pisavector.xcassets */; };
 		ABDAFB44FD9859A9FE77424E /* Pods_DocsCode.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EF6577E027F75C7D93ED70A6 /* Pods_DocsCode.framework */; };
 		BBD05676206B24335DEA52C4 /* Pods_ExamplesUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7692D1D792EB3849E8754E6B /* Pods_ExamplesUITests.framework */; };
+		DAE87506209041D600638AAB /* NavigationTutorialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05AB82441FBC09AB005FB704 /* NavigationTutorialViewController.swift */; };
+		DAE87507209041DD00638AAB /* NavigationTutorialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 05AB82471FBC0D41005FB704 /* NavigationTutorialViewController.m */; };
 		DD5939E41E6639BA0009BEB2 /* ClusteringExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD5939E31E6639BA0009BEB2 /* ClusteringExample.swift */; };
 		DD5939E61E6778480009BEB2 /* clustering.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DD5939E51E6778480009BEB2 /* clustering.xcassets */; };
 		DDF943291E5DE63300545D0F /* ClusteringExample.m in Sources */ = {isa = PBXBuildFile; fileRef = DDF943281E5DE63300545D0F /* ClusteringExample.m */; };
@@ -1168,11 +1170,27 @@
 				"${SRCROOT}/Pods/Target Support Files/Pods-DocsCode/Pods-DocsCode-frameworks.sh",
 				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework",
 				"${PODS_ROOT}/Mapbox-iOS-SDK/dynamic/Mapbox.framework.dSYM",
+				"${BUILT_PRODUCTS_DIR}/MapboxCoreNavigation/MapboxCoreNavigation.framework",
+				"${BUILT_PRODUCTS_DIR}/MapboxDirections.swift/MapboxDirections.framework",
+				"${BUILT_PRODUCTS_DIR}/MapboxMobileEvents/MapboxMobileEvents.framework",
+				"${BUILT_PRODUCTS_DIR}/MapboxNavigation/MapboxNavigation.framework",
+				"${BUILT_PRODUCTS_DIR}/MapboxSpeech/MapboxSpeech.framework",
+				"${BUILT_PRODUCTS_DIR}/Polyline/Polyline.framework",
+				"${BUILT_PRODUCTS_DIR}/Solar/Solar.framework",
+				"${BUILT_PRODUCTS_DIR}/Turf/Turf.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mapbox.framework",
 				"${DWARF_DSYM_FOLDER_PATH}/Mapbox.framework.dSYM",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxCoreNavigation.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxDirections.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxMobileEvents.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxNavigation.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxSpeech.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Polyline.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Solar.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Turf.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1243,7 +1261,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				0597C0D2207FCA540045DE7C /* DDSCircleLayerTutorialViewController.m in Sources */,
+				DAE87507209041DD00638AAB /* NavigationTutorialViewController.m in Sources */,
 				0597C0D1207FCA4D0045DE7C /* DDSCircleLayerTutorialViewController.swift in Sources */,
+				DAE87506209041D600638AAB /* NavigationTutorialViewController.swift in Sources */,
 				050337411F7199DF007309B0 /* AppDelegate.swift in Sources */,
 				0597C0D3207FCDD20045DE7C /* FirstStepsTutorialViewController.m in Sources */,
 				0597C0D4207FCDD40045DE7C /* FirstStepsTutorialViewController.swift in Sources */,

--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ platform :ios, '8.0'
 use_frameworks!
 
 def shared_pods
-    pod 'Mapbox-iOS-SDK', podspec: 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.0.0/platform/ios/Mapbox-iOS-SDK.podspec'
+    pod 'Mapbox-iOS-SDK', '~> 4.0.0'
 end
 
 target 'Examples' do
@@ -11,7 +11,8 @@ end
 
 target 'DocsCode' do
   platform :ios, '9.0'
-  #pod 'MapboxNavigation', '~> 0.11'
+  pod 'MapboxCoreNavigation', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-navigation-ios/v0.17.0-beta.1/MapboxCoreNavigation.podspec'
+  pod 'MapboxNavigation', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-navigation-ios/v0.17.0-beta.1/MapboxNavigation.podspec'
   shared_pods
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,54 @@
 PODS:
   - Mapbox-iOS-SDK (4.0.0)
+  - MapboxCoreNavigation (0.17.0-beta.1):
+    - MapboxDirections.swift (~> 0.20.0)
+    - MapboxMobileEvents (~> 0.4)
+    - Turf (~> 0.1)
+  - MapboxDirections.swift (0.20.0):
+    - Polyline (~> 4.2)
+  - MapboxMobileEvents (0.4.0)
+  - MapboxNavigation (0.17.0-beta.1):
+    - Mapbox-iOS-SDK (~> 4.0)
+    - MapboxCoreNavigation (= 0.17.0-beta.1)
+    - MapboxSpeech (~> 0.0.1)
+    - Solar (~> 2.1)
+  - MapboxSpeech (0.0.1)
+  - Polyline (4.2.0)
+  - Solar (2.1.0)
+  - Turf (0.1.1)
 
 DEPENDENCIES:
-  - Mapbox-iOS-SDK (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.0.0/platform/ios/Mapbox-iOS-SDK.podspec`)
+  - Mapbox-iOS-SDK (~> 4.0.0)
+  - MapboxCoreNavigation (from `https://raw.githubusercontent.com/mapbox/mapbox-navigation-ios/v0.17.0-beta.1/MapboxCoreNavigation.podspec`)
+  - MapboxNavigation (from `https://raw.githubusercontent.com/mapbox/mapbox-navigation-ios/v0.17.0-beta.1/MapboxNavigation.podspec`)
+
+SPEC REPOS:
+  https://github.com/CocoaPods/Specs.git:
+    - Mapbox-iOS-SDK
+    - MapboxDirections.swift
+    - MapboxMobileEvents
+    - MapboxSpeech
+    - Polyline
+    - Solar
+    - Turf
 
 EXTERNAL SOURCES:
-  Mapbox-iOS-SDK:
-    :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.0.0/platform/ios/Mapbox-iOS-SDK.podspec
+  MapboxCoreNavigation:
+    :podspec: https://raw.githubusercontent.com/mapbox/mapbox-navigation-ios/v0.17.0-beta.1/MapboxCoreNavigation.podspec
+  MapboxNavigation:
+    :podspec: https://raw.githubusercontent.com/mapbox/mapbox-navigation-ios/v0.17.0-beta.1/MapboxNavigation.podspec
 
 SPEC CHECKSUMS:
   Mapbox-iOS-SDK: 271754e96eb4434ba1b0a8c68432e1ea26fe9841
+  MapboxCoreNavigation: 2f84ea58a6dd555b278994c750981e32ed4cb2a9
+  MapboxDirections.swift: 9a46ca0f0608c76393f392ae793459cc30aa846f
+  MapboxMobileEvents: e71cf788a95fa0c01ad6ce17fd5efd13140af5ff
+  MapboxNavigation: d75ec22bfdf6946bf8f791e941cfeccd5c745945
+  MapboxSpeech: 6cc9b3d53adc2988af3ebc704dd17907b84a3f9f
+  Polyline: 3d69f75bb136357e27291d439d0436c6ebda57a4
+  Solar: 2dc6e7cc39186cb0c8228fa08df76fb50c7d8f24
+  Turf: 4ace207379c8d58a8e45842755de821dac3fae72
 
-PODFILE CHECKSUM: ba99d67f3c0fc808d37edcb9e1a9d942c80aa59a
+PODFILE CHECKSUM: 3121d6b2eb4dc288551d5a9283c5a66e08b11c2e
 
 COCOAPODS: 1.5.0


### PR DESCRIPTION
Added the navigation SDK tutorial back to the DocsCode target, undoing one of the changes described in https://github.com/mapbox/ios-sdk-examples/pull/143#issuecomment-381796510. Upgraded to navigation SDK v0.17.0-beta.1. ~~For now, that beta is on a branch; once mapbox/mapbox-navigation-ios#1336 is released, we can use a tag instead.~~

/cc @captainbarbosa @colleenmcginnis @friedbunny