### PR TITLE
Require map's gestures to fail before accepting our taps

### DIFF
--- a/Examples/ObjectiveC/ClusteringExample.m
+++ b/Examples/ObjectiveC/ClusteringExample.m
@@ -22,6 +22,15 @@ NSString *const MBXExampleClustering = @"ClusteringExample";
     self.mapView.delegate = self;
     [self.view addSubview:self.mapView];
 
+    // Add our own gesture recognizer to handle taps on our custom map features. This gesture requires the built-in MGLMapView tap gestures (such as those for zoom and annotation selection) to fail.
+    UITapGestureRecognizer *singleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleMapTap:)];
+    for (UIGestureRecognizer *recognizer in self.mapView.gestureRecognizers) {
+        if ([recognizer isKindOfClass:[UITapGestureRecognizer class]]) {
+            [singleTap requireGestureRecognizerToFail:recognizer];
+        }
+    }
+    [self.mapView addGestureRecognizer:singleTap];
+
     self.icon = [UIImage imageNamed:@"port"];
 }
 
@@ -68,16 +77,13 @@ NSString *const MBXExampleClustering = @"ClusteringExample";
     numbersLayer.text = [NSExpression expressionWithFormat:@"CAST(point_count, 'NSString')"];
     numbersLayer.predicate = [NSPredicate predicateWithFormat:@"cluster == YES"];
     [style addLayer:numbersLayer];
-
-    // Add a tap gesture for zooming in to clusters or showing popups on individual features.
-    [self.view addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)]];
 }
 
 - (void)mapViewRegionIsChanging:(MGLMapView *)mapView {
     [self showPopup:NO animated:NO];
 }
 
-- (void)handleTap:(UITapGestureRecognizer *)tap {
+- (IBAction)handleMapTap:(UITapGestureRecognizer *)tap {
     if (tap.state == UIGestureRecognizerStateEnded) {
         CGPoint point = [tap locationInView:tap.view];
         CGFloat width = self.icon.size.width;

--- a/Examples/ObjectiveC/FeatureSelectionExample.m
+++ b/Examples/ObjectiveC/FeatureSelectionExample.m
@@ -24,15 +24,18 @@ NSString const *MBXExampleFeatureSelection = @"FeatureSelectionExample";
 
     // Store the name of the style layer in which states will be drawn.
     self.layerIdentifier = @"state-layer";
-    
-    // Add a tap gesture recognizer to the map view.
-    UITapGestureRecognizer *gesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTap:)];
-    gesture.numberOfTapsRequired = 1;
-    [self.mapView addGestureRecognizer:gesture];
+
+    // Add our own gesture recognizer to handle taps on our custom map features. This gesture requires the built-in MGLMapView tap gestures (such as those for zoom and annotation selection) to fail.
+    UITapGestureRecognizer *singleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleMapTap:)];
+    for (UIGestureRecognizer *recognizer in self.mapView.gestureRecognizers) {
+        if ([recognizer isKindOfClass:[UITapGestureRecognizer class]]) {
+            [singleTap requireGestureRecognizerToFail:recognizer];
+        }
+    }
+    [self.mapView addGestureRecognizer:singleTap];
 }
 
 - (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {
-    
     // Load a tileset containing U.S. states and their population density. For more information about working with tilesets, see: https://www.mapbox.com/help/studio-manual-tilesets/
     NSURL *url = [NSURL URLWithString:@"mapbox://examples.69ytlgls"];
     
@@ -60,8 +63,7 @@ NSString const *MBXExampleFeatureSelection = @"FeatureSelectionExample";
     [style insertLayer:layer belowLayer:symbolLayer];
 }
 
-- (void)handleTap:(UITapGestureRecognizer *)gesture {
-    
+- (IBAction)handleMapTap:(UITapGestureRecognizer *)gesture {
     // Get the CGPoint where the user tapped.
     CGPoint spot = [gesture locationInView:self.mapView];
     

--- a/Examples/ObjectiveC/PointConversionExample.m
+++ b/Examples/ObjectiveC/PointConversionExample.m
@@ -17,7 +17,7 @@ NSString *const MBXExamplePointConversion = @"PointConversionExample";
     [self.view addSubview:self.mapView];
 
     // Add a single tap gesture recognizer. This gesture requires the built-in MGLMapView tap gestures (such as those for zoom and annotation selection) to fail.
-    UITapGestureRecognizer *singleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleSingleTap:)];
+    UITapGestureRecognizer *singleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleMapTap:)];
     for (UIGestureRecognizer *recognizer in self.mapView.gestureRecognizers) {
         if ([recognizer isKindOfClass:[UITapGestureRecognizer class]]) {
             [singleTap requireGestureRecognizerToFail:recognizer];
@@ -30,7 +30,7 @@ NSString *const MBXExamplePointConversion = @"PointConversionExample";
     NSLog(@"Screen center: %@ = %@", NSStringFromCGPoint(centerScreenPoint), NSStringFromCGPoint(self.mapView.center));
 }
 
-- (void)handleSingleTap:(UITapGestureRecognizer *)tap {
+- (IBAction)handleMapTap:(UITapGestureRecognizer *)tap {
     // Convert tap location (CGPoint) to geographic coordinate (CLLocationCoordinate2D).
     CGPoint tapPoint = [tap locationInView:self.mapView];
     CLLocationCoordinate2D tapCoordinate = [self.mapView convertPoint:tapPoint toCoordinateFromView:nil];

--- a/Examples/ObjectiveC/SelectFeatureExample.m
+++ b/Examples/ObjectiveC/SelectFeatureExample.m
@@ -13,22 +13,23 @@ NSString *const MBXExampleSelectFeature = @"SelectFeatureExample";
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-    MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
+    self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
+    self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
-    mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(45.5076, -122.6736) zoomLevel:11 animated:NO];
 
-    [mapView setCenterCoordinate:CLLocationCoordinate2DMake(45.5076, -122.6736)
-                       zoomLevel:11
-                        animated:NO];
+    // Add our own gesture recognizer to handle taps on our custom map features. This gesture requires the built-in MGLMapView tap gestures (such as those for zoom and annotation selection) to fail.
+    UITapGestureRecognizer *singleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(didTapMap:)];
+    for (UIGestureRecognizer *recognizer in self.mapView.gestureRecognizers) {
+        if ([recognizer isKindOfClass:[UITapGestureRecognizer class]]) {
+            [singleTap requireGestureRecognizerToFail:recognizer];
+        }
+    }
+    [self.mapView addGestureRecognizer:singleTap];
 
-    // Add our own gesture recognizer to handle taps on our custom map features
-    [mapView addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(didTapMap:)]];
+    self.mapView.delegate = self;
 
-    mapView.delegate = self;
-
-    [self.view addSubview:mapView];
-
-    self.mapView = mapView;
+    [self.view addSubview:self.mapView];
 }
 
 - (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {
@@ -46,7 +47,7 @@ NSString *const MBXExampleSelectFeature = @"SelectFeatureExample";
     [style addLayer:selectedFeaturesLayer];
 }
 
-- (void)didTapMap:(UITapGestureRecognizer *)recognizer {
+- (IBAction)didTapMap:(UITapGestureRecognizer *)recognizer {
     if (recognizer.state == UIGestureRecognizerStateEnded) {
         // A tap’s center coordinate may not intersect a feature exactly, so let’s make a 44x44 rect that represents a touch and select all features that interesect.
         CGRect pointRect = { [recognizer locationInView:recognizer.view], CGSizeZero };

--- a/Examples/ObjectiveC/WebAPIDataExample.m
+++ b/Examples/ObjectiveC/WebAPIDataExample.m
@@ -12,20 +12,23 @@ NSString *const MBXExampleWebAPIData = @"WebAPIDataExample";
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-    MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
+    self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
+    self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
-    mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(37.090240, -95.712891) zoomLevel:2 animated:NO];
 
-    [mapView setCenterCoordinate:CLLocationCoordinate2DMake(37.090240, -95.712891) zoomLevel:2 animated:NO];
+    self.mapView.delegate = self;
 
-    mapView.delegate = self;
+    // Add our own gesture recognizer to handle taps on our custom map features. This gesture requires the built-in MGLMapView tap gestures (such as those for zoom and annotation selection) to fail.
+    UITapGestureRecognizer *singleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleMapTap:)];
+    for (UIGestureRecognizer *recognizer in self.mapView.gestureRecognizers) {
+        if ([recognizer isKindOfClass:[UITapGestureRecognizer class]]) {
+            [singleTap requireGestureRecognizerToFail:recognizer];
+        }
+    }
+    [self.mapView addGestureRecognizer:singleTap];
 
-    // Add our own gesture recognizer to handle taps on our custom map features.
-    [mapView addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleMapTap:)]];
-
-    [self.view addSubview:mapView];
-
-    self.mapView = mapView;
+    [self.view addSubview:self.mapView];
 }
 
 - (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {
@@ -82,7 +85,7 @@ NSString *const MBXExampleWebAPIData = @"WebAPIDataExample";
 
 #pragma mark - Feature interaction
 
-- (void)handleMapTap:(UITapGestureRecognizer *)sender {
+- (IBAction)handleMapTap:(UITapGestureRecognizer *)sender {
     if (sender.state == UIGestureRecognizerStateEnded) {
         // Limit feature selection to just the following layer identifiers.
         NSArray *layerIdentifiers = @[@"lighthouse-symbols", @"lighthouse-circles"];

--- a/Examples/Swift/ClusteringExample.swift
+++ b/Examples/Swift/ClusteringExample.swift
@@ -17,6 +17,13 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
         mapView.delegate = self
         view.addSubview(mapView)
 
+        // Add a single tap gesture recognizer. This gesture requires the built-in MGLMapView tap gestures (such as those for zoom and annotation selection) to fail.
+        let singleTap = UITapGestureRecognizer(target: self, action: #selector(handleMapTap(sender:)))
+        for recognizer in mapView.gestureRecognizers! where recognizer is UITapGestureRecognizer {
+            singleTap.require(toFail: recognizer)
+        }
+        mapView.addGestureRecognizer(singleTap)
+
         icon = UIImage(named: "port")
     }
 
@@ -65,18 +72,15 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
         
         numbersLayer.predicate = NSPredicate(format: "cluster == YES")
         style.addLayer(numbersLayer)
-
-        // Add a tap gesture for zooming in to clusters or showing popups on individual features.
-        view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap(_:))))
     }
 
     func mapViewRegionIsChanging(_ mapView: MGLMapView) {
         showPopup(false, animated: false)
     }
 
-    @objc func handleTap(_ tap: UITapGestureRecognizer) {
-        if tap.state == .ended {
-            let point = tap.location(in: tap.view)
+    @objc @IBAction func handleMapTap(sender: UITapGestureRecognizer) {
+        if sender.state == .ended {
+            let point = sender.location(in: sender.view)
             let width = icon.size.width
             let rect = CGRect(x: point.x - width / 2, y: point.y - width / 2, width: width, height: width)
 

--- a/Examples/Swift/FeatureSelectionExample.swift
+++ b/Examples/Swift/FeatureSelectionExample.swift
@@ -2,7 +2,7 @@ import Mapbox
 
 @objc(FeatureSelectionExample_Swift)
 
-class FeatureSelectionExample_Swift: UIViewController, MGLMapViewDelegate, UIGestureRecognizerDelegate {
+class FeatureSelectionExample_Swift: UIViewController, MGLMapViewDelegate {
     
     var mapView: MGLMapView!
     let layerIdentifier = "state-layer"
@@ -16,13 +16,15 @@ class FeatureSelectionExample_Swift: UIViewController, MGLMapViewDelegate, UIGes
         mapView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         view.addSubview(mapView)
         
-        // Add a tap gesture recognizer to the map view.
-        let gesture = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
-        mapView.addGestureRecognizer(gesture)
+        // Add a single tap gesture recognizer. This gesture requires the built-in MGLMapView tap gestures (such as those for zoom and annotation selection) to fail.
+        let singleTap = UITapGestureRecognizer(target: self, action: #selector(handleMapTap(sender:)))
+        for recognizer in mapView.gestureRecognizers! where recognizer is UITapGestureRecognizer {
+            singleTap.require(toFail: recognizer)
+        }
+        mapView.addGestureRecognizer(singleTap)
     }
     
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
-        
         // Load a tileset containing U.S. states and their population density. For more information about working with tilesets, see: https://www.mapbox.com/help/studio-manual-tilesets/
         let url = URL(string: "mapbox://examples.69ytlgls")!
         let source = MGLVectorTileSource(identifier: "state-source", configurationURL: url)
@@ -46,10 +48,9 @@ class FeatureSelectionExample_Swift: UIViewController, MGLMapViewDelegate, UIGes
         style.insertLayer(layer, below: symbolLayer!)
     }
     
-    @objc func handleTap(_ gesture: UITapGestureRecognizer) {
-        
+    @objc @IBAction func handleMapTap(sender: UITapGestureRecognizer) {
         // Get the CGPoint where the user tapped.
-        let spot = gesture.location(in: mapView)
+        let spot = sender.location(in: mapView)
         
         // Access the features at that point within the state layer.
         let features = mapView.visibleFeatures(at: spot, styleLayerIdentifiers: Set([layerIdentifier]))

--- a/Examples/Swift/PointConversionExample.swift
+++ b/Examples/Swift/PointConversionExample.swift
@@ -13,7 +13,7 @@ class PointConversionExample_Swift: UIViewController, MGLMapViewDelegate {
         view.addSubview(mapView)
 
         // Add a single tap gesture recognizer. This gesture requires the built-in MGLMapView tap gestures (such as those for zoom and annotation selection) to fail.
-        let singleTap = UITapGestureRecognizer(target: self, action: #selector(handleSingleTap(tap:)))
+        let singleTap = UITapGestureRecognizer(target: self, action: #selector(handleMapTap(sender:)))
         for recognizer in mapView.gestureRecognizers! where recognizer is UITapGestureRecognizer {
             singleTap.require(toFail: recognizer)
         }
@@ -24,9 +24,9 @@ class PointConversionExample_Swift: UIViewController, MGLMapViewDelegate {
         print("Screen center: \(centerScreenPoint) = \(mapView.center)")
     }
     
-    @objc func handleSingleTap(tap: UITapGestureRecognizer) {
+    @objc @IBAction func handleMapTap(sender: UITapGestureRecognizer) {
         // Convert tap location (CGPoint) to geographic coordinate (CLLocationCoordinate2D).
-        let tapPoint: CGPoint = tap.location(in: mapView)
+        let tapPoint: CGPoint = sender.location(in: mapView)
         let tapCoordinate: CLLocationCoordinate2D = mapView.convert(tapPoint, toCoordinateFrom: nil)
         print("You tapped at: \(tapCoordinate.latitude), \(tapCoordinate.longitude)")
         

--- a/Examples/Swift/SelectFeatureExample.swift
+++ b/Examples/Swift/SelectFeatureExample.swift
@@ -9,21 +9,18 @@ class SelectFeatureExample_Swift: UIViewController, MGLMapViewDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let mapView = MGLMapView(frame: view.bounds)
+        mapView = MGLMapView(frame: view.bounds)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-
-        mapView.setCenter(
-            CLLocationCoordinate2D(latitude: 45.5076, longitude: -122.6736),
-            zoomLevel: 11,
-            animated: false)
-        view.addSubview(mapView)
-        
-        // Add our own gesture recognizer to handle taps on our custom map features.
-        mapView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapMap(tapGestureRecognizer:))))
-        
+        mapView.setCenter(CLLocationCoordinate2D(latitude: 45.5076, longitude: -122.6736), zoomLevel: 11, animated: false)
         mapView.delegate = self
-        
-        self.mapView = mapView
+        view.addSubview(mapView)
+
+        // Add a single tap gesture recognizer. This gesture requires the built-in MGLMapView tap gestures (such as those for zoom and annotation selection) to fail.
+        let singleTap = UITapGestureRecognizer(target: self, action: #selector(handleMapTap(sender:)))
+        for recognizer in mapView.gestureRecognizers! where recognizer is UITapGestureRecognizer {
+            singleTap.require(toFail: recognizer)
+        }
+        mapView.addGestureRecognizer(singleTap)
     }
     
     func mapView(_ didFinishLoadingmapView: MGLMapView, didFinishLoading style: MGLStyle) {
@@ -41,10 +38,10 @@ class SelectFeatureExample_Swift: UIViewController, MGLMapViewDelegate {
         style.addLayer(selectedFeaturesLayer)
     }
     
-    @objc func didTapMap(tapGestureRecognizer: UITapGestureRecognizer) {
-        if tapGestureRecognizer.state == .ended {
+    @objc @IBAction func handleMapTap(sender: UITapGestureRecognizer) {
+        if sender.state == .ended {
             // A tap’s center coordinate may not intersect a feature exactly, so let’s make a 44x44 rect that represents a touch and select all features that intersect.
-            let point = tapGestureRecognizer.location(in: tapGestureRecognizer.view!)
+            let point = sender.location(in: sender.view!)
             let touchRect = CGRect(origin: point, size: .zero).insetBy(dx: -22.0, dy: -22.0)
             
             // Let’s only select parks near the rect. There’s a layer within the Mapbox Streets style with "id" = "park". You can see all of the layers used within the default mapbox styles by creating a new style using Mapbox Studio.

--- a/Examples/Swift/WebAPIDataExample.swift
+++ b/Examples/Swift/WebAPIDataExample.swift
@@ -8,19 +8,18 @@ class WebAPIDataExample_Swift: UIViewController, MGLMapViewDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let mapView = MGLMapView(frame: view.bounds)
+        mapView = MGLMapView(frame: view.bounds)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-
         mapView.setCenter(CLLocationCoordinate2D(latitude: 37.090240, longitude: -95.712891), zoomLevel: 2, animated: false)
-
         mapView.delegate = self
-
         view.addSubview(mapView)
 
-        // Add our own gesture recognizer to handle taps on our custom map features.
-        mapView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleMapTap(sender:))))
-        
-        self.mapView = mapView
+        // Add a single tap gesture recognizer. This gesture requires the built-in MGLMapView tap gestures (such as those for zoom and annotation selection) to fail.
+        let singleTap = UITapGestureRecognizer(target: self, action: #selector(handleMapTap(sender:)))
+        for recognizer in mapView.gestureRecognizers! where recognizer is UITapGestureRecognizer {
+            singleTap.require(toFail: recognizer)
+        }
+        mapView.addGestureRecognizer(singleTap)
     }
 
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
@@ -63,7 +62,7 @@ class WebAPIDataExample_Swift: UIViewController, MGLMapViewDelegate {
         symbols.iconOpacity = NSExpression(format: "mgl_interpolate:withCurveType:parameters:stops:($zoomLevel, 'linear', nil, %@)",
                                            [5.9: 0, 6: 1])
 
-//        // "name" references the "name" key in an MGLPointFeature’s attributes dictionary.
+        // "name" references the "name" key in an MGLPointFeature’s attributes dictionary.
         symbols.text = NSExpression(forKeyPath: "name")
         symbols.textColor = symbols.iconColor
         symbols.textFontSize = NSExpression(format: "mgl_interpolate:withCurveType:parameters:stops:($zoomLevel, 'linear', nil, %@)",
@@ -80,7 +79,7 @@ class WebAPIDataExample_Swift: UIViewController, MGLMapViewDelegate {
     }
 
     // MARK: - Feature interaction
-    @objc func handleMapTap(sender: UITapGestureRecognizer) {
+    @objc @IBAction func handleMapTap(sender: UITapGestureRecognizer) {
         if sender.state == .ended {
             // Limit feature selection to just the following layer identifiers.
             let layerIdentifiers: Set = ["lighthouse-symbols", "lighthouse-circles"]


### PR DESCRIPTION
Fixes #162 by adding missing gesture failure checks.

It’s always necessary to check if the map view will handle a tap gesture before an example does, otherwise it’s possible to, e.g., have a double tap on an annotation both zoom and select-then-deselect that annotation.

/cc @jmkiley @captainbarbosa @lilykaiser 