### PR TITLE
Update tutorial code for data-driven styling tutorial

### DIFF
--- a/DocsCode/DDSCircleLayerTutorial/DDSCircleLayerTutorialViewController.m
+++ b/DocsCode/DDSCircleLayerTutorial/DDSCircleLayerTutorialViewController.m
@@ -16,8 +16,9 @@
     
     mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     
-    mapView.centerCoordinate = CLLocationCoordinate2DMake(44.971, -93.261);
-    mapView.zoomLevel = 10;
+    [mapView setCenterCoordinate:CLLocationCoordinate2DMake(44.971, -93.261)
+                       zoomLevel:10
+                        animated:NO];
     
     [self.view addSubview:mapView];
     mapView.delegate = self;
@@ -41,8 +42,8 @@
     layer.circleOpacity = [NSExpression expressionForConstantValue:@"0.8"];
 
     NSDictionary *zoomStops = @{
-                                @10: [NSExpression expressionWithFormat:@"(Constructi - 2018) / 30"],
-                                @13: [NSExpression expressionWithFormat:@"(Constructi - 2018) / 10"]
+        @10: [NSExpression expressionWithFormat:@"(2018 - Constructi) / 30"],
+        @13: [NSExpression expressionWithFormat:@"(2018 - Constructi) / 10"]
     };
     
     layer.circleRadius = [NSExpression expressionWithFormat:@"mgl_interpolate:withCurveType:parameters:stops:(Constructi, 'linear', nil, %@)", zoomStops];

--- a/DocsCode/DDSCircleLayerTutorial/DDSCircleLayerTutorialViewController.swift
+++ b/DocsCode/DDSCircleLayerTutorial/DDSCircleLayerTutorialViewController.swift
@@ -11,8 +11,7 @@ class DDSCircleLayerTutorialViewController: UIViewController, MGLMapViewDelegate
         mapView.styleURL = MGLStyle.lightStyleURL
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         
-        mapView.setCenter(CLLocationCoordinate2D(latitude: 44.971, longitude: -93.261), animated: false)
-        mapView.zoomLevel = 10
+        mapView.setCenter(CLLocationCoordinate2D(latitude: 44.971, longitude: -93.261), zoomLevel: 10, animated: false)
         
         mapView.delegate = self
         view.addSubview(mapView)
@@ -30,13 +29,13 @@ class DDSCircleLayerTutorialViewController: UIViewController, MGLMapViewDelegate
         
         layer.sourceLayerIdentifier = "HPC_landmarks-b60kqn"
         
-        layer.circleColor = NSExpression(forConstantValue: UIColor(red: 0.67, green: 0.28, blue: 0.13, alpha: 1.0))
+        layer.circleColor = NSExpression(forConstantValue: #colorLiteral(red: 0.67, green: 0.28, blue: 0.13, alpha: 1))
         
         layer.circleOpacity = NSExpression(forConstantValue: 0.8)
         
         let zoomStops = [
-            10: NSExpression(format: "(Constructi - 2018) / 30"),
-            13: NSExpression(format: "(Constructi - 2018) / 10")
+            10: NSExpression(format: "(2018 - Constructi) / 30"),
+            13: NSExpression(format: "(2018 - Constructi) / 10")
         ]
         
         layer.circleRadius = NSExpression(format: "mgl_interpolate:withCurveType:parameters:stops:($zoomLevel, 'linear', nil, %@)", zoomStops)


### PR DESCRIPTION
Minor code updates to the `DDSCircleLayerTutorial` in the DocsCode target in preparation for updating the [iOS data-driven styling tutorial](https://github.com/mapbox/help/issues/1495).

- Use `-setCenterCoordinate:zoomLevel:animated:` instead of `zoomLevel` and `centerCoordinate` for both Swift and Objective-C
- Fix expression string format for both Swift and Objective-C
- Objective-C: Clean up indentation
- Swift: Use color literals in Swift file