### PR TITLE
Switched to using bounds rather than frame for cornerRadius (as frame changes when rotated).

### DIFF
--- a/Examples/ObjectiveC/AnnotationViewExample.m
+++ b/Examples/ObjectiveC/AnnotationViewExample.m
@@ -12,10 +12,6 @@ NSString *const MBXExampleAnnotationView = @"AnnotationViewExample";
 - (void)layoutSubviews {
     [super layoutSubviews];
 
-    // Force the annotation view to maintain a constant size when the map is tilted.
-    self.scalesWithViewingDistance = NO;
-    self.rotatesToMatchCamera = YES;
-
     // Use CALayer’s corner radius to turn this view into a circle.
     self.layer.cornerRadius = self.bounds.size.width / 2;
     self.layer.borderWidth = 2;

--- a/Examples/ObjectiveC/AnnotationViewExample.m
+++ b/Examples/ObjectiveC/AnnotationViewExample.m
@@ -13,10 +13,11 @@ NSString *const MBXExampleAnnotationView = @"AnnotationViewExample";
     [super layoutSubviews];
 
     // Force the annotation view to maintain a constant size when the map is tilted.
-    self.scalesWithViewingDistance = false;
+    self.scalesWithViewingDistance = NO;
+    self.rotatesToMatchCamera = YES;
 
     // Use CALayer’s corner radius to turn this view into a circle.
-    self.layer.cornerRadius = self.frame.size.width / 2;
+    self.layer.cornerRadius = self.bounds.size.width / 2;
     self.layer.borderWidth = 2;
     self.layer.borderColor = [UIColor whiteColor].CGColor;
 }
@@ -27,7 +28,7 @@ NSString *const MBXExampleAnnotationView = @"AnnotationViewExample";
     // Animate the border width in/out, creating an iris effect.
     CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"borderWidth"];
     animation.duration = 0.1;
-    self.layer.borderWidth = selected ? self.frame.size.width / 4 : 2;
+    self.layer.borderWidth = selected ? self.bounds.size.width / 4 : 2;
     [self.layer addAnimation:animation forKey:@"borderWidth"];
 }
 
@@ -92,7 +93,7 @@ NSString *const MBXExampleAnnotationView = @"AnnotationViewExample";
     // If there’s no reusable annotation view available, initialize a new one.
     if (!annotationView) {
         annotationView = [[CustomAnnotationView alloc] initWithReuseIdentifier:reuseIdentifier];
-        annotationView.frame = CGRectMake(0, 0, 40, 40);
+        annotationView.bounds = CGRectMake(0, 0, 40, 40);
 
         // Set the annotation view’s background color to a value determined by its longitude.
         CGFloat hue = (CGFloat)annotation.coordinate.longitude / 100;


### PR DESCRIPTION
Partly addresses https://github.com/mapbox/mapbox-gl-native/issues/11756 (also added `rotatesToMatchCamera = YES` to test).

See also https://github.com/mapbox/mapbox-gl-native/pull/11817 for the associated change in mapbox-gl-native.

