### PR TITLE
Initial XCUITest handling

### DIFF
--- a/Examples.xcodeproj/project.pbxproj
+++ b/Examples.xcodeproj/project.pbxproj
@@ -125,6 +125,10 @@
 		BBD05676206B24335DEA52C4 /* Pods_ExamplesUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7692D1D792EB3849E8754E6B /* Pods_ExamplesUITests.framework */; };
 		DAE87506209041D600638AAB /* NavigationTutorialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05AB82441FBC09AB005FB704 /* NavigationTutorialViewController.swift */; };
 		DAE87507209041DD00638AAB /* NavigationTutorialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 05AB82471FBC0D41005FB704 /* NavigationTutorialViewController.m */; };
+		CA39B2BF209B881300D37037 /* BuildingLightExample+UITesting.m in Sources */ = {isa = PBXBuildFile; fileRef = CA39B2BA209B881300D37037 /* BuildingLightExample+UITesting.m */; };
+		CA39B2C0209B881300D37037 /* AnimatedLineExample+UITesting.m in Sources */ = {isa = PBXBuildFile; fileRef = CA39B2BB209B881300D37037 /* AnimatedLineExample+UITesting.m */; };
+		CA39B2C1209B881300D37037 /* AnnotationViewExample+UITesting.m in Sources */ = {isa = PBXBuildFile; fileRef = CA39B2BC209B881300D37037 /* AnnotationViewExample+UITesting.m */; };
+		CA39B2C2209B881300D37037 /* ForwardingMapViewDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = CA39B2BD209B881300D37037 /* ForwardingMapViewDelegate.m */; };
 		CA3B162C2098C724005C087B /* TestingSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = CA3B162B2098C724005C087B /* TestingSupport.m */; };
 		CA3B162E2098CA7E005C087B /* TestingSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = CA3B162B2098C724005C087B /* TestingSupport.m */; };
 		DD5939E41E6639BA0009BEB2 /* ClusteringExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD5939E31E6639BA0009BEB2 /* ClusteringExample.swift */; };
@@ -365,6 +369,11 @@
 		9A1ECC25B13FE3249B26BE0A /* Pods-Shared-DocsCode.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shared-DocsCode.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Shared-DocsCode/Pods-Shared-DocsCode.debug.xcconfig"; sourceTree = "<group>"; };
 		9EC12D8F1A97963D68BFA871 /* Pods_Examples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Examples.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C057E98F506AAA58F0473788 /* Pods-Shared-Examples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shared-Examples.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Shared-Examples/Pods-Shared-Examples.debug.xcconfig"; sourceTree = "<group>"; };
+		CA39B2BA209B881300D37037 /* BuildingLightExample+UITesting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "BuildingLightExample+UITesting.m"; sourceTree = "<group>"; };
+		CA39B2BB209B881300D37037 /* AnimatedLineExample+UITesting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AnimatedLineExample+UITesting.m"; sourceTree = "<group>"; };
+		CA39B2BC209B881300D37037 /* AnnotationViewExample+UITesting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "AnnotationViewExample+UITesting.m"; sourceTree = "<group>"; };
+		CA39B2BD209B881300D37037 /* ForwardingMapViewDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ForwardingMapViewDelegate.m; sourceTree = "<group>"; };
+		CA39B2BE209B881300D37037 /* ForwardingMapViewDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ForwardingMapViewDelegate.h; sourceTree = "<group>"; };
 		CA3B162B2098C724005C087B /* TestingSupport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestingSupport.m; sourceTree = "<group>"; };
 		CA3B162D2098C7B3005C087B /* TestingSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestingSupport.h; sourceTree = "<group>"; };
 		DD5939E31E6639BA0009BEB2 /* ClusteringExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClusteringExample.swift; sourceTree = "<group>"; };
@@ -679,7 +688,6 @@
 		3EBCD6FA1DC26355001E342F /* Objective-C */ = {
 			isa = PBXGroup;
 			children = (
-				CA3B162A2098C6FF005C087B /* Testing Support */,
 				0543F64E1FE8697800D0AF54 /* 3D */,
 				0543F64C1FE868EE00D0AF54 /* Dynamic styling */,
 				0543F6481FE8688E00D0AF54 /* Getting started */,
@@ -857,6 +865,8 @@
 		9691AAA01C5AAD8F006A58C6 /* Code */ = {
 			isa = PBXGroup;
 			children = (
+				CA39B2B9209B881300D37037 /* Testing Categories */,
+				CA3B162A2098C6FF005C087B /* Testing Support */,
 				3EBCD6FC1DC26364001E342F /* Swift */,
 				3EBCD6FA1DC26355001E342F /* Objective-C */,
 			);
@@ -882,6 +892,19 @@
 			);
 			name = Pods;
 			sourceTree = "<group>";
+		};
+		CA39B2B9209B881300D37037 /* Testing Categories */ = {
+			isa = PBXGroup;
+			children = (
+				CA39B2BA209B881300D37037 /* BuildingLightExample+UITesting.m */,
+				CA39B2BB209B881300D37037 /* AnimatedLineExample+UITesting.m */,
+				CA39B2BC209B881300D37037 /* AnnotationViewExample+UITesting.m */,
+				CA39B2BD209B881300D37037 /* ForwardingMapViewDelegate.m */,
+				CA39B2BE209B881300D37037 /* ForwardingMapViewDelegate.h */,
+			);
+			name = "Testing Categories";
+			path = "Examples/Testing Categories";
+			sourceTree = SOURCE_ROOT;
 		};
 		CA3B162A2098C6FF005C087B /* Testing Support */ = {
 			isa = PBXGroup;
@@ -1311,6 +1334,7 @@
 				962B450F1D1C8520007B7454 /* AnnotationViewExample.m in Sources */,
 				1F1F84771E53A3B700332CC3 /* BlockingGesturesDelegateExample.swift in Sources */,
 				05536CB2200F9B0900657097 /* SwitchStylesExample.m in Sources */,
+				CA39B2C0209B881300D37037 /* AnimatedLineExample+UITesting.m in Sources */,
 				3ED403411E006B5200230C95 /* CameraFlyToExample.swift in Sources */,
 				9691AAA91C5AAD8F006A58C6 /* SimpleMapViewExample.m in Sources */,
 				960A21611D344F9F00BB348B /* DraggableAnnotationViewExample.m in Sources */,
@@ -1369,6 +1393,7 @@
 				9691AA941C5AA702006A58C6 /* Examples.m in Sources */,
 				3EBCD7201DC28240001E342F /* DraggableAnnotationViewExample.swift in Sources */,
 				3EBCD7281DC28240001E342F /* SimpleMapViewExample.swift in Sources */,
+				CA39B2C2209B881300D37037 /* ForwardingMapViewDelegate.m in Sources */,
 				3EBCD7241DC28240001E342F /* PolygonAnnotationExample.swift in Sources */,
 				05FA53981FE2FA00001F3D7D /* SatelliteStyleExample.m in Sources */,
 				964CB5111E42A0A3004549EA /* AnnotationViewsAndImagesExample.swift in Sources */,
@@ -1384,6 +1409,7 @@
 				05FA53A71FE2FA34001F3D7D /* StaticSnapshotExample.m in Sources */,
 				3EBCD71C1DC28240001E342F /* CustomCalloutViewExample.swift in Sources */,
 				05FA53AD1FE2FBB3001F3D7D /* CalloutDelegateUsageExample.m in Sources */,
+				CA39B2C1209B881300D37037 /* AnnotationViewExample+UITesting.m in Sources */,
 				DDF943291E5DE63300545D0F /* ClusteringExample.m in Sources */,
 				3E44BA58203B54260072DE4B /* MultipleImagesExample.m in Sources */,
 				3EBCD7171DC28240001E342F /* CalloutDelegateUsageExample.swift in Sources */,
@@ -1398,6 +1424,7 @@
 				05FA53A11FE2FA1E001F3D7D /* PolygonPatternExample.m in Sources */,
 				3E3FB66E1F0588B3004512C6 /* BuildingLightExample.m in Sources */,
 				968247271C5C1DC700494AB8 /* CameraAnimationExample.m in Sources */,
+				CA39B2BF209B881300D37037 /* BuildingLightExample+UITesting.m in Sources */,
 				961962D51C583FDC002D3DAB /* ExamplesContainerViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples.xcodeproj/project.pbxproj
+++ b/Examples.xcodeproj/project.pbxproj
@@ -125,6 +125,8 @@
 		BBD05676206B24335DEA52C4 /* Pods_ExamplesUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7692D1D792EB3849E8754E6B /* Pods_ExamplesUITests.framework */; };
 		DAE87506209041D600638AAB /* NavigationTutorialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05AB82441FBC09AB005FB704 /* NavigationTutorialViewController.swift */; };
 		DAE87507209041DD00638AAB /* NavigationTutorialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 05AB82471FBC0D41005FB704 /* NavigationTutorialViewController.m */; };
+		CA3B162C2098C724005C087B /* TestingSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = CA3B162B2098C724005C087B /* TestingSupport.m */; };
+		CA3B162E2098CA7E005C087B /* TestingSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = CA3B162B2098C724005C087B /* TestingSupport.m */; };
 		DD5939E41E6639BA0009BEB2 /* ClusteringExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD5939E31E6639BA0009BEB2 /* ClusteringExample.swift */; };
 		DD5939E61E6778480009BEB2 /* clustering.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DD5939E51E6778480009BEB2 /* clustering.xcassets */; };
 		DDF943291E5DE63300545D0F /* ClusteringExample.m in Sources */ = {isa = PBXBuildFile; fileRef = DDF943281E5DE63300545D0F /* ClusteringExample.m */; };
@@ -363,6 +365,8 @@
 		9A1ECC25B13FE3249B26BE0A /* Pods-Shared-DocsCode.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shared-DocsCode.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Shared-DocsCode/Pods-Shared-DocsCode.debug.xcconfig"; sourceTree = "<group>"; };
 		9EC12D8F1A97963D68BFA871 /* Pods_Examples.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Examples.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C057E98F506AAA58F0473788 /* Pods-Shared-Examples.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shared-Examples.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Shared-Examples/Pods-Shared-Examples.debug.xcconfig"; sourceTree = "<group>"; };
+		CA3B162B2098C724005C087B /* TestingSupport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestingSupport.m; sourceTree = "<group>"; };
+		CA3B162D2098C7B3005C087B /* TestingSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestingSupport.h; sourceTree = "<group>"; };
 		DD5939E31E6639BA0009BEB2 /* ClusteringExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClusteringExample.swift; sourceTree = "<group>"; };
 		DD5939E51E6778480009BEB2 /* clustering.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = clustering.xcassets; sourceTree = "<group>"; };
 		DDF943271E5DE63300545D0F /* ClusteringExample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ClusteringExample.h; sourceTree = "<group>"; };
@@ -675,6 +679,7 @@
 		3EBCD6FA1DC26355001E342F /* Objective-C */ = {
 			isa = PBXGroup;
 			children = (
+				CA3B162A2098C6FF005C087B /* Testing Support */,
 				0543F64E1FE8697800D0AF54 /* 3D */,
 				0543F64C1FE868EE00D0AF54 /* Dynamic styling */,
 				0543F6481FE8688E00D0AF54 /* Getting started */,
@@ -876,6 +881,15 @@
 				2ECF27F4ACA1A3CA05DE1954 /* Pods-DocsCode.release.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		CA3B162A2098C6FF005C087B /* Testing Support */ = {
+			isa = PBXGroup;
+			children = (
+				CA3B162B2098C724005C087B /* TestingSupport.m */,
+				CA3B162D2098C7B3005C087B /* TestingSupport.h */,
+			);
+			name = "Testing Support";
 			sourceTree = "<group>";
 		};
 		CBAD5BE154F4126883B2A6DC /* Frameworks */ = {
@@ -1324,6 +1338,7 @@
 				3E085B831EC526E500163C99 /* BuildingsExample.m in Sources */,
 				3E9EF27C209CFD460053D1D7 /* HeatmapExample.swift in Sources */,
 				64BBDAF61DF232FD00BB705D /* SelectFeatureExample.swift in Sources */,
+				CA3B162E2098CA7E005C087B /* TestingSupport.m in Sources */,
 				64BBDAF81DF2330B00BB705D /* SelectFeatureExample.m in Sources */,
 				96D431FC1C84B4F7007D09D1 /* ImageAnnotationExample.m in Sources */,
 				3E3FB66B1F05888E004512C6 /* BuildingLightExample.swift in Sources */,
@@ -1399,6 +1414,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CA3B162C2098C724005C087B /* TestingSupport.m in Sources */,
 				961962B51C581700002D3DAB /* ExamplesUITests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/ObjectiveC/AnimatedLineExample.m
+++ b/Examples/ObjectiveC/AnimatedLineExample.m
@@ -68,7 +68,7 @@ NSString *const MBXExampleAnimatedLine = @"AnimatedLineExample";
         [_timer invalidate];
         _timer = nil;
 
-        testingSupportPostExampleCompleteNotification();
+        testingSupportPostNotification(MBXTestingSupportNotificationExampleComplete);
         return;
     }
 

--- a/Examples/ObjectiveC/AnimatedLineExample.m
+++ b/Examples/ObjectiveC/AnimatedLineExample.m
@@ -1,4 +1,5 @@
 #import "AnimatedLineExample.h"
+#import "TestingSupport.h"
 @import Mapbox;
 
 NSString *const MBXExampleAnimatedLine = @"AnimatedLineExample";
@@ -66,6 +67,8 @@ NSString *const MBXExampleAnimatedLine = @"AnimatedLineExample";
     if (_currentIndex > self.locations.count) {
         [_timer invalidate];
         _timer = nil;
+
+        testingSupportPostExampleCompleteNotification();
         return;
     }
 

--- a/Examples/ObjectiveC/AnimatedLineExample.m
+++ b/Examples/ObjectiveC/AnimatedLineExample.m
@@ -4,14 +4,12 @@
 
 NSString *const MBXExampleAnimatedLine = @"AnimatedLineExample";
 
-@interface AnimatedLineExample () <MGLMapViewDelegate> {
-    int _currentIndex;
-    NSTimer *_timer;
-}
+@interface AnimatedLineExample () <MGLMapViewDelegate>
 
 @property (nonatomic) MGLMapView *mapView;
 @property (nonatomic) MGLShapeSource *polylineSource;
 @property (nonatomic) NSArray<CLLocation *> *locations;
+@property (nonatomic) NSInteger currentIndex;
 
 @end
 
@@ -21,15 +19,16 @@ NSString *const MBXExampleAnimatedLine = @"AnimatedLineExample";
     [super viewDidLoad];
 
     self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
+    self.mapView.delegate = self;
+
     self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
     [self.mapView setCenterCoordinate:CLLocationCoordinate2DMake(45.5076, -122.6736)
-			    zoomLevel:11
-			     animated:NO];
+                            zoomLevel:11
+                             animated:NO];
 
     [self.view addSubview:self.mapView];
 
-    self.mapView.delegate = self;
 }
 
 // Wait until the map is loaded before adding to the map.
@@ -57,18 +56,15 @@ NSString *const MBXExampleAnimatedLine = @"AnimatedLineExample";
 }
 
 - (void)animatePolyline {
-    _currentIndex = 1;
+    self.currentIndex = 1;
 
     // Start a timer that will simulate adding points to our polyline. This could also represent coordinates being added to our polyline from another source, such as a CLLocationManagerDelegate.
-    _timer = [NSTimer scheduledTimerWithTimeInterval:0.05 target:self selector:@selector(tick) userInfo:nil repeats:YES];
+    [NSTimer scheduledTimerWithTimeInterval:0.05 target:self selector:@selector(tick:) userInfo:nil repeats:YES];
 }
 
-- (void)tick {
-    if (_currentIndex > self.locations.count) {
-        [_timer invalidate];
-        _timer = nil;
-
-        testingSupportPostNotification(MBXTestingSupportNotificationExampleComplete);
+- (void)tick:(NSTimer*)timer {
+    if (self.currentIndex > self.locations.count) {
+        [timer invalidate];
         return;
     }
 
@@ -78,7 +74,7 @@ NSString *const MBXExampleAnimatedLine = @"AnimatedLineExample";
     // Update our MGLShapeSource with the current locations.
     [self updatePolylineWithLocations:currentLocations];
 
-    _currentIndex++;
+    self.currentIndex++;
 }
 
 - (void)updatePolylineWithLocations:(NSArray<CLLocation *> *)locations {

--- a/Examples/ObjectiveC/AnimatedLineExample.m
+++ b/Examples/ObjectiveC/AnimatedLineExample.m
@@ -1,5 +1,4 @@
 #import "AnimatedLineExample.h"
-#import "TestingSupport.h"
 @import Mapbox;
 
 NSString *const MBXExampleAnimatedLine = @"AnimatedLineExample";

--- a/Examples/ObjectiveC/AnnotationViewExample.m
+++ b/Examples/ObjectiveC/AnnotationViewExample.m
@@ -1,5 +1,4 @@
 #import "AnnotationViewExample.h"
-#import "TestingSupport.h"
 @import Mapbox;
 
 NSString *const MBXExampleAnnotationView = @"AnnotationViewExample";
@@ -49,7 +48,6 @@ NSString *const MBXExampleAnnotationView = @"AnnotationViewExample";
     mapView.centerCoordinate = CLLocationCoordinate2DMake(0, 66);
     mapView.zoomLevel = 2;
     mapView.delegate = self;
-
     [self.view addSubview:mapView];
 
     // Specify coordinates for our annotations.

--- a/Examples/ObjectiveC/AnnotationViewExample.m
+++ b/Examples/ObjectiveC/AnnotationViewExample.m
@@ -50,12 +50,6 @@ NSString *const MBXExampleAnnotationView = @"AnnotationViewExample";
     mapView.zoomLevel = 2;
     mapView.delegate = self;
 
-    // For UI Testing
-    mapView.isAccessibilityElement = NO;
-    mapView.accessibilityIdentifier = @"MGLMapViewId";
-    mapView.compassView.isAccessibilityElement = NO;
-    mapView.compassView.accessibilityIdentifier = @"MGLMapViewCompassId";
-                                                    
     [self.view addSubview:mapView];
 
     // Specify coordinates for our annotations.
@@ -80,14 +74,6 @@ NSString *const MBXExampleAnnotationView = @"AnnotationViewExample";
 }
 
 #pragma mark - MGLMapViewDelegate methods
-
-- (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style   {
-    testingSupportPostNotification(MBXTestingSupportNotificationMapViewStyleLoaded);
-}
-
-- (void)mapViewDidFinishRenderingMap:(MGLMapView *)mapView fullyRendered:(BOOL)fullyRendered {
-    testingSupportPostNotification(MBXTestingSupportNotificationMapViewRendered);
-}
 
 // This delegate method is where you tell the map to load a view for a specific annotation. To load a static MGLAnnotationImage, you would use `-mapView:imageForAnnotation:`.
 - (MGLAnnotationView *)mapView:(MGLMapView *)mapView viewForAnnotation:(id <MGLAnnotation>)annotation {

--- a/Examples/ObjectiveC/AnnotationViewExample.m
+++ b/Examples/ObjectiveC/AnnotationViewExample.m
@@ -1,4 +1,5 @@
 #import "AnnotationViewExample.h"
+#import "TestingSupport.h"
 @import Mapbox;
 
 NSString *const MBXExampleAnnotationView = @"AnnotationViewExample";
@@ -48,6 +49,13 @@ NSString *const MBXExampleAnnotationView = @"AnnotationViewExample";
     mapView.centerCoordinate = CLLocationCoordinate2DMake(0, 66);
     mapView.zoomLevel = 2;
     mapView.delegate = self;
+
+    // For UI Testing
+    mapView.isAccessibilityElement = NO;
+    mapView.accessibilityIdentifier = @"MGLMapViewId";
+    mapView.compassView.isAccessibilityElement = NO;
+    mapView.compassView.accessibilityIdentifier = @"MGLMapViewCompassId";
+                                                    
     [self.view addSubview:mapView];
 
     // Specify coordinates for our annotations.
@@ -72,6 +80,14 @@ NSString *const MBXExampleAnnotationView = @"AnnotationViewExample";
 }
 
 #pragma mark - MGLMapViewDelegate methods
+
+- (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style   {
+    testingSupportPostNotification(MBXTestingSupportNotificationMapViewStyleLoaded);
+}
+
+- (void)mapViewDidFinishRenderingMap:(MGLMapView *)mapView fullyRendered:(BOOL)fullyRendered {
+    testingSupportPostNotification(MBXTestingSupportNotificationMapViewRendered);
+}
 
 // This delegate method is where you tell the map to load a view for a specific annotation. To load a static MGLAnnotationImage, you would use `-mapView:imageForAnnotation:`.
 - (MGLAnnotationView *)mapView:(MGLMapView *)mapView viewForAnnotation:(id <MGLAnnotation>)annotation {

--- a/Examples/ObjectiveC/BuildingLightExample.m
+++ b/Examples/ObjectiveC/BuildingLightExample.m
@@ -1,5 +1,6 @@
 
 #import "BuildingLightExample.h"
+#import "TestingSupport.h"
 @import Mapbox;
 
 @interface BuildingLightExample () <MGLMapViewDelegate>
@@ -21,7 +22,11 @@ NSString *const MBXExampleBuildingLight = @"BuildingLightExample";
     self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle streetsStyleURLWithVersion:9]];
     self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.mapView.delegate = self;
-    
+
+    // For UI Testing
+    self.mapView.isAccessibilityElement = NO;
+    self.mapView.accessibilityIdentifier = @"MGLMapViewId";
+
     // Center the map on the Flatiron Building in New York, NY.
     self.mapView.camera = [MGLMapCamera cameraLookingAtCenterCoordinate:CLLocationCoordinate2DMake(40.7411, -73.9897) fromDistance:600 pitch:45 heading:200];
     
@@ -37,6 +42,11 @@ NSString *const MBXExampleBuildingLight = @"BuildingLightExample";
     self.slider.minimumValue = -180;
     self.slider.maximumValue = 180;
     self.slider.value = 0;
+
+    // For UI testing
+    self.slider.isAccessibilityElement = NO;
+    self.slider.accessibilityIdentifier = @"SliderId";
+
     [self.slider addTarget:self action:@selector(shiftLight) forControlEvents:UIControlEventValueChanged];
     [self.view addSubview:self.slider];
 }
@@ -61,6 +71,12 @@ NSString *const MBXExampleBuildingLight = @"BuildingLightExample";
     self.light.anchor = [NSExpression expressionForConstantValue:@"map"];
     
     style.light = self.light;
+
+    testingSupportPostNotification(MBXTestingSupportNotificationMapViewStyleLoaded);
+}
+
+- (void)mapViewDidFinishRenderingMap:(MGLMapView *)mapView fullyRendered:(BOOL)fullyRendered {
+    testingSupportPostNotification(MBXTestingSupportNotificationMapViewRendered);
 }
 
 - (void)shiftLight {

--- a/Examples/ObjectiveC/BuildingLightExample.m
+++ b/Examples/ObjectiveC/BuildingLightExample.m
@@ -23,10 +23,6 @@ NSString *const MBXExampleBuildingLight = @"BuildingLightExample";
     self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.mapView.delegate = self;
 
-    // For UI Testing
-    self.mapView.isAccessibilityElement = NO;
-    self.mapView.accessibilityIdentifier = @"MGLMapViewId";
-
     // Center the map on the Flatiron Building in New York, NY.
     self.mapView.camera = [MGLMapCamera cameraLookingAtCenterCoordinate:CLLocationCoordinate2DMake(40.7411, -73.9897) fromDistance:600 pitch:45 heading:200];
     
@@ -42,10 +38,6 @@ NSString *const MBXExampleBuildingLight = @"BuildingLightExample";
     self.slider.minimumValue = -180;
     self.slider.maximumValue = 180;
     self.slider.value = 0;
-
-    // For UI testing
-    self.slider.isAccessibilityElement = NO;
-    self.slider.accessibilityIdentifier = @"SliderId";
 
     [self.slider addTarget:self action:@selector(shiftLight) forControlEvents:UIControlEventValueChanged];
     [self.view addSubview:self.slider];
@@ -71,12 +63,6 @@ NSString *const MBXExampleBuildingLight = @"BuildingLightExample";
     self.light.anchor = [NSExpression expressionForConstantValue:@"map"];
     
     style.light = self.light;
-
-    testingSupportPostNotification(MBXTestingSupportNotificationMapViewStyleLoaded);
-}
-
-- (void)mapViewDidFinishRenderingMap:(MGLMapView *)mapView fullyRendered:(BOOL)fullyRendered {
-    testingSupportPostNotification(MBXTestingSupportNotificationMapViewRendered);
 }
 
 - (void)shiftLight {

--- a/Examples/ObjectiveC/BuildingLightExample.m
+++ b/Examples/ObjectiveC/BuildingLightExample.m
@@ -1,6 +1,5 @@
 
 #import "BuildingLightExample.h"
-#import "TestingSupport.h"
 @import Mapbox;
 
 @interface BuildingLightExample () <MGLMapViewDelegate>
@@ -22,7 +21,7 @@ NSString *const MBXExampleBuildingLight = @"BuildingLightExample";
     self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle streetsStyleURLWithVersion:9]];
     self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.mapView.delegate = self;
-
+     
     // Center the map on the Flatiron Building in New York, NY.
     self.mapView.camera = [MGLMapCamera cameraLookingAtCenterCoordinate:CLLocationCoordinate2DMake(40.7411, -73.9897) fromDistance:600 pitch:45 heading:200];
     
@@ -38,7 +37,6 @@ NSString *const MBXExampleBuildingLight = @"BuildingLightExample";
     self.slider.minimumValue = -180;
     self.slider.maximumValue = 180;
     self.slider.value = 0;
-
     [self.slider addTarget:self action:@selector(shiftLight) forControlEvents:UIControlEventValueChanged];
     [self.view addSubview:self.slider];
 }

--- a/Examples/ObjectiveC/TestingSupport.h
+++ b/Examples/ObjectiveC/TestingSupport.h
@@ -1,5 +1,9 @@
 @import Foundation;
 
-FOUNDATION_EXTERN NSString * const testingSupportExampleCompleteNotificationName;
+typedef NSString *MBXTestingSupportNotification NS_TYPED_ENUM;
 
-FOUNDATION_EXTERN void testingSupportPostExampleCompleteNotification(void);
+extern const MBXTestingSupportNotification MBXTestingSupportNotificationExampleComplete;
+extern const MBXTestingSupportNotification MBXTestingSupportNotificationMapViewStyleLoaded;
+extern const MBXTestingSupportNotification MBXTestingSupportNotificationMapViewRendered;
+
+FOUNDATION_EXTERN void testingSupportPostNotification(MBXTestingSupportNotification name);

--- a/Examples/ObjectiveC/TestingSupport.h
+++ b/Examples/ObjectiveC/TestingSupport.h
@@ -1,0 +1,5 @@
+@import Foundation;
+
+FOUNDATION_EXTERN NSString * const testingSupportExampleCompleteNotificationName;
+
+FOUNDATION_EXTERN void testingSupportPostExampleCompleteNotification(void);

--- a/Examples/ObjectiveC/TestingSupport.m
+++ b/Examples/ObjectiveC/TestingSupport.m
@@ -1,0 +1,8 @@
+#import "TestingSupport.h"
+
+NSString * const testingSupportExampleCompleteNotificationName = @"com.mapbox.examples.example-complete";
+
+void testingSupportPostExampleCompleteNotification(void) {
+    CFNotificationCenterRef center = CFNotificationCenterGetDarwinNotifyCenter();
+    CFNotificationCenterPostNotification(center, (CFNotificationName)testingSupportExampleCompleteNotificationName, NULL, NULL, true);
+}

--- a/Examples/ObjectiveC/TestingSupport.m
+++ b/Examples/ObjectiveC/TestingSupport.m
@@ -1,8 +1,10 @@
 #import "TestingSupport.h"
 
-NSString * const testingSupportExampleCompleteNotificationName = @"com.mapbox.examples.example-complete";
+const MBXTestingSupportNotification MBXTestingSupportNotificationExampleComplete = @"com.mapbox.examples.example-complete";
+const MBXTestingSupportNotification MBXTestingSupportNotificationMapViewStyleLoaded = @"com.mapbox.examples.mapview-style-loaded";
+const MBXTestingSupportNotification MBXTestingSupportNotificationMapViewRendered = @"com.mapbox.examples.mapview-rendered";
 
-void testingSupportPostExampleCompleteNotification(void) {
+void testingSupportPostNotification(MBXTestingSupportNotification name) {
     CFNotificationCenterRef center = CFNotificationCenterGetDarwinNotifyCenter();
-    CFNotificationCenterPostNotification(center, (CFNotificationName)testingSupportExampleCompleteNotificationName, NULL, NULL, true);
+    CFNotificationCenterPostNotification(center, (CFNotificationName)name, NULL, NULL, true);
 }

--- a/Examples/Testing Categories/AnimatedLineExample+UITesting.m
+++ b/Examples/Testing Categories/AnimatedLineExample+UITesting.m
@@ -1,0 +1,44 @@
+@import Foundation;
+@import Mapbox;
+
+#import "TestingSupport.h"
+#import "ForwardingMapViewDelegate.h"
+#import "AnimatedLineExample.h"
+
+static void *currentIndexObservationContext = &currentIndexObservationContext;
+
+@interface AnimatedLineExample (AnimatedLineExample_UITesting)
+@property (nonatomic) NSInteger currentIndex;
+@property (nonatomic) MGLMapView *mapView;
+@property (nonatomic) NSArray<CLLocation *> *locations;
+@end
+
+@implementation AnimatedLineExample (AnimatedLineExample_UITesting)
+@dynamic currentIndex;
+@dynamic mapView;
+@dynamic locations;
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self setupForTesting];
+}
+
+- (void)setupForTesting {
+    [ForwardingMapViewDelegate addToMapView:self.mapView];
+
+    [self addObserver:self
+           forKeyPath:@"currentIndex"
+              options:NSKeyValueObservingOptionNew|NSKeyValueObservingOptionInitial
+              context:currentIndexObservationContext];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context {
+    if ((context == currentIndexObservationContext) &&
+        (self.currentIndex > self.locations.count)) {
+        [self removeObserver:self forKeyPath:@"currentIndex"];
+
+        testingSupportPostNotification(MBXTestingSupportNotificationExampleComplete);
+    }
+}
+
+@end

--- a/Examples/Testing Categories/AnnotationViewExample+UITesting.m
+++ b/Examples/Testing Categories/AnnotationViewExample+UITesting.m
@@ -1,0 +1,41 @@
+@import Foundation;
+@import Mapbox;
+
+#import "TestingSupport.h"
+#import "ForwardingMapViewDelegate.h"
+#import "AnnotationViewExample.h"
+
+@interface AnnotationViewExample (UITesting)
+@end
+
+@implementation AnnotationViewExample (UITesting)
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self setupForTesting];
+}
+
+- (void)setupForTesting {
+
+    MGLMapView* mapView;
+
+    for (UIView *view in self.view.subviews) {
+        if ([view isKindOfClass:[MGLMapView class]]) {
+            mapView = (MGLMapView*)view;
+            break;
+        }
+    }
+
+    assert(mapView);
+
+    // For UI Testing
+    mapView.isAccessibilityElement = NO;
+    mapView.accessibilityIdentifier = @"MGLMapViewId";
+    mapView.compassView.isAccessibilityElement = NO;
+    mapView.compassView.accessibilityIdentifier = @"MGLMapViewCompassId";
+
+    [ForwardingMapViewDelegate addToMapView:mapView];
+}
+
+
+@end

--- a/Examples/Testing Categories/BuildingLightExample+UITesting.m
+++ b/Examples/Testing Categories/BuildingLightExample+UITesting.m
@@ -1,0 +1,34 @@
+@import Foundation;
+@import Mapbox;
+
+#import "TestingSupport.h"
+#import "ForwardingMapViewDelegate.h"
+#import "BuildingLightExample.h"
+
+@interface BuildingLightExample (UITesting)
+@property (nonatomic) MGLMapView *mapView;
+@property (nonatomic) UISlider *slider;
+@end
+
+@implementation BuildingLightExample (UITesting)
+@dynamic mapView;
+@dynamic slider;
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self setupForTesting];
+}
+
+- (void)setupForTesting {
+    // For UI Testing
+    self.mapView.isAccessibilityElement = NO;
+    self.mapView.accessibilityIdentifier = @"MGLMapViewId";
+
+    // For UI testing
+    self.slider.isAccessibilityElement = NO;
+    self.slider.accessibilityIdentifier = @"SliderId";
+
+    [ForwardingMapViewDelegate addToMapView:self.mapView];
+}
+@end
+

--- a/Examples/Testing Categories/ForwardingMapViewDelegate.h
+++ b/Examples/Testing Categories/ForwardingMapViewDelegate.h
@@ -1,0 +1,11 @@
+@import Foundation;
+@import Mapbox;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ForwardingMapViewDelegate: NSObject <MGLMapViewDelegate>
+@property (nonatomic, weak, nullable) NSObject<MGLMapViewDelegate> *delegate;
++ (void)addToMapView:(MGLMapView*)mapView;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Examples/Testing Categories/ForwardingMapViewDelegate.m
+++ b/Examples/Testing Categories/ForwardingMapViewDelegate.m
@@ -1,0 +1,71 @@
+#import "ForwardingMapViewDelegate.h"
+#import "TestingSupport.h"
+#import <objc/runtime.h>
+
+static void * forwardingMapViewAssociationStaticKey = &forwardingMapViewAssociationStaticKey;
+
+@implementation ForwardingMapViewDelegate
+
++ (void)addToMapView:(MGLMapView*)mapView {
+    ForwardingMapViewDelegate *forwarder = [[ForwardingMapViewDelegate alloc] init];
+    forwarder.delegate = mapView.delegate;
+    mapView.delegate = forwarder;
+
+    objc_setAssociatedObject(mapView, forwardingMapViewAssociationStaticKey, forwarder, OBJC_ASSOCIATION_RETAIN);
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation {
+    if ([self.delegate respondsToSelector:[invocation selector]]) {
+        [invocation invokeWithTarget:self.delegate];
+    }
+}
+
+- (BOOL)respondsToSelector:(SEL)aSelector {
+
+    static NSMutableDictionary *rts = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        rts = [NSMutableDictionary dictionary];
+    });
+
+    NSString *selectorName = NSStringFromSelector(aSelector);
+
+    NSNumber *rtsNumber = rts[selectorName];
+
+    if (rtsNumber) {
+        return [rtsNumber boolValue];
+    }
+
+    BOOL responds = ([super respondsToSelector:aSelector] ||
+                     [self.delegate respondsToSelector:aSelector]);
+
+    rts[selectorName] = @(responds);
+
+    return responds;
+}
+
+- (NSMethodSignature*)methodSignatureForSelector:(SEL)selector {
+    NSMethodSignature* signature = [super methodSignatureForSelector:selector];
+    if (!signature) {
+        signature = [self.delegate methodSignatureForSelector:selector];
+    }
+    return signature;
+}
+
+- (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {
+    if ([self.delegate respondsToSelector:_cmd]) {
+        [self.delegate mapView:mapView didFinishLoadingStyle:style];
+    }
+
+    testingSupportPostNotification(MBXTestingSupportNotificationMapViewStyleLoaded);
+}
+
+- (void)mapViewDidFinishRenderingMap:(MGLMapView *)mapView fullyRendered:(BOOL)fullyRendered {
+    if ([self.delegate respondsToSelector:_cmd]) {
+        [self.delegate mapViewDidFinishRenderingMap:mapView fullyRendered:fullyRendered];
+    }
+
+    testingSupportPostNotification(MBXTestingSupportNotificationMapViewRendered);
+}
+
+@end

--- a/ExamplesUITests/ExamplesUITests.m
+++ b/ExamplesUITests/ExamplesUITests.m
@@ -84,7 +84,7 @@
     // Wait, just so we can see something
     [XCTContext runActivityNamed:@"Wait" block:^(id<XCTActivity>  _Nonnull activity) {
         XCTestExpectation *expectation = [self expectationWithDescription:@"wait"];
-        (void)[XCTWaiter waitForExpectations:@[expectation] timeout:10.0]; // Let it timeout
+        (void)[XCTWaiter waitForExpectations:@[expectation] timeout:3.0]; // Let it timeout
 
         [app.navigationBars[@"AnnotationViewExample"].buttons[@"Examples"] tap];
     }];

--- a/ExamplesUITests/ExamplesUITests.m
+++ b/ExamplesUITests/ExamplesUITests.m
@@ -34,13 +34,40 @@
 - (void)testEveryExample {
     XCUIApplication *app = [[XCUIApplication alloc] init];
 
-    for (int i = 0; i < app.tables.cells.count; i++) {
-        [app.tables.cells.allElementsBoundByIndex[i] tap];
+    __block NSUInteger count;
+    __block NSMutableArray<XCUIElement*> *elements;
+    __block NSMutableArray<NSString*> *titles;
 
-        // XCTest waits for the app to idle before continuing.
+    // Build arrays of the examples (so the report can be broken into readable
+    // activities)
+    [XCTContext runActivityNamed:@"Get examples"
+                           block:^(id<XCTActivity>  _Nonnull activity) {
 
-        // Tap 'Back' button.
-        [app.navigationBars.buttons.allElementsBoundByIndex.firstObject tap];
+                               XCUIElementQuery *cells = app.tables.cells;
+                               count = cells.count;
+
+                               elements = [NSMutableArray arrayWithCapacity:count];
+                               titles = [NSMutableArray arrayWithCapacity:count];
+
+                               for (int i = 0; i < count; i++) {
+                                   XCUIElement *el = cells.allElementsBoundByIndex[i];
+                                   NSString *title = [[el.staticTexts element] label];
+
+                                   [elements addObject:el];
+                                   [titles addObject:title];
+                               }
+                           }];
+
+    for (NSUInteger i = 0; i < count; i++) {
+        [XCTContext runActivityNamed:titles[i]
+                               block:^(id<XCTActivity>  _Nonnull activity) {
+            [elements[i] tap];
+                                   
+            // XCTest waits for the app to idle before continuing.
+
+           // Tap 'Back' button.
+           [app.navigationBars.buttons.allElementsBoundByIndex.firstObject tap];
+        }];
     }
 }
 

--- a/ExamplesUITests/ExamplesUITests.m
+++ b/ExamplesUITests/ExamplesUITests.m
@@ -8,6 +8,7 @@
 
 #import <XCTest/XCTest.h>
 #import "Examples.h"
+#import "TestingSupport.h"
 
 @interface ExamplesUITests : XCTestCase
 
@@ -31,22 +32,89 @@
     [super tearDown];
 }
 
+/**
+ testAnimatedLineExample
+ Wait for the line to be fully animated
+ */
 - (void)testAnimatedLineExample {
 
-    [XCTContext runActivityNamed:@"AnimatedLineExample"
-                           block:^(id<XCTActivity>  _Nonnull activity) {
+    XCUIApplication *app = [[XCUIApplication alloc] init];
 
-                               XCUIApplication *app = [[XCUIApplication alloc] init];
-                               [app.tables.staticTexts[@"AnimatedLineExample"] tap];
+    [XCTContext runActivityNamed:@"AnimatedLineExample" block:^(id<XCTActivity>  _Nonnull activity) {
+        [app.tables.staticTexts[@"AnimatedLineExample"] tap];
 
-                               // Wait for notification
-                               XCTDarwinNotificationExpectation *expectation = [[XCTDarwinNotificationExpectation alloc] initWithNotificationName:@"com.mapbox.examples.example-complete"];
+        // Wait for notification
+        XCTDarwinNotificationExpectation *expectation = [[XCTDarwinNotificationExpectation alloc] initWithNotificationName:MBXTestingSupportNotificationExampleComplete];
+        [self waitForExpectations:@[expectation] timeout:30.0];
 
-                               [self waitForExpectations:@[expectation] timeout:30.0];
-
-                               [app.navigationBars[@"AnimatedLineExample"].buttons[@"Examples"] tap];
-                           }];
+        [app.navigationBars[@"AnimatedLineExample"].buttons[@"Examples"] tap];
+    }];
 }
+
+/**
+ testCustomAnnotationView
+ Zoom and rotate the map.
+ */
+- (void)testCustomAnnotationView {
+    XCUIApplication *app = [[XCUIApplication alloc] init];
+
+    __block XCUIElement *element;
+    __block XCUIElement *compass;
+
+    [XCTContext runActivityNamed:@"Wait for initial render" block:^(id<XCTActivity>  _Nonnull activity) {
+        [app.tables.staticTexts[@"AnnotationViewExample"] tap];
+        XCUIElementQuery *allQuery = [app descendantsMatchingType:XCUIElementTypeAny];
+        element = [allQuery elementMatchingType:XCUIElementTypeAny identifier:@"MGLMapViewId"];
+        compass = [allQuery elementMatchingType:XCUIElementTypeAny identifier:@"MGLMapViewCompassId"];
+
+        XCTDarwinNotificationExpectation *expectation = [[XCTDarwinNotificationExpectation alloc] initWithNotificationName:MBXTestingSupportNotificationMapViewRendered];
+        [self waitForExpectations:@[expectation] timeout:10.0];
+    }];
+
+    [XCTContext runActivityNamed:@"Pinch & Rotate" block:^(id<XCTActivity>  _Nonnull activity) {
+        [element pinchWithScale:2 velocity:10.0];
+        [element rotate:M_PI*0.75 withVelocity:M_PI*0.75]; // should take 1 second
+        [element pinchWithScale:0.20 velocity:-10.0];
+
+        [compass tap];
+    }];
+
+    // TODO: Check orientation & shape of annotations.
+
+    // Wait, just so we can see something
+    [XCTContext runActivityNamed:@"Wait" block:^(id<XCTActivity>  _Nonnull activity) {
+        XCTestExpectation *expectation = [self expectationWithDescription:@"wait"];
+        (void)[XCTWaiter waitForExpectations:@[expectation] timeout:10.0]; // Let it timeout
+
+        [app.navigationBars[@"AnnotationViewExample"].buttons[@"Examples"] tap];
+    }];
+}
+
+- (void)testBuildingLightExample {
+    XCUIApplication *app = [[XCUIApplication alloc] init];
+
+    __block XCUIElement *element;
+    __block XCUIElement *slider;
+
+    [XCTContext runActivityNamed:@"Wait for initial render" block:^(id<XCTActivity>  _Nonnull activity) {
+        [app.tables.staticTexts[@"BuildingLightExample"] tap];
+        XCUIElementQuery *allQuery = [app descendantsMatchingType:XCUIElementTypeAny];
+        element = [allQuery elementMatchingType:XCUIElementTypeAny identifier:@"MGLMapViewId"];
+        slider = [allQuery elementMatchingType:XCUIElementTypeSlider identifier:@"SliderId"];
+
+        XCTDarwinNotificationExpectation *expectation = [[XCTDarwinNotificationExpectation alloc] initWithNotificationName:MBXTestingSupportNotificationMapViewRendered];
+        [self waitForExpectations:@[expectation] timeout:10.0];
+    }];
+
+    [XCTContext runActivityNamed:@"Adjust light" block:^(id<XCTActivity>  _Nonnull activity) {
+        [slider adjustToNormalizedSliderPosition:0.0];
+        [slider adjustToNormalizedSliderPosition:1.0];
+        [slider adjustToNormalizedSliderPosition:0.5];
+    }];
+
+    [app.navigationBars[@"BuildingLightExample"].buttons[@"Examples"] tap];
+}
+
 
 - (void)testEveryExample {
     XCUIApplication *app = [[XCUIApplication alloc] init];
@@ -57,33 +125,31 @@
 
     // Build arrays of the examples (so the report can be broken into readable
     // activities)
-    [XCTContext runActivityNamed:@"Get examples"
-                           block:^(id<XCTActivity>  _Nonnull activity) {
+    [XCTContext runActivityNamed:@"Get examples" block:^(id<XCTActivity>  _Nonnull activity) {
 
-                               XCUIElementQuery *cells = app.tables.cells;
-                               count = cells.count;
+        XCUIElementQuery *cells = app.tables.cells;
+        count = cells.count;
 
-                               elements = [NSMutableArray arrayWithCapacity:count];
-                               titles = [NSMutableArray arrayWithCapacity:count];
+        elements = [NSMutableArray arrayWithCapacity:count];
+        titles = [NSMutableArray arrayWithCapacity:count];
 
-                               for (int i = 0; i < count; i++) {
-                                   XCUIElement *el = cells.allElementsBoundByIndex[i];
-                                   NSString *title = [[el.staticTexts element] label];
+        for (int i = 0; i < count; i++) {
+            XCUIElement *el = cells.allElementsBoundByIndex[i];
+            NSString *title = [[el.staticTexts element] label];
 
-                                   [elements addObject:el];
-                                   [titles addObject:title];
-                               }
-                           }];
+            [elements addObject:el];
+            [titles addObject:title];
+        }
+    }];
 
     for (NSUInteger i = 0; i < count; i++) {
-        [XCTContext runActivityNamed:titles[i]
-                               block:^(id<XCTActivity>  _Nonnull activity) {
+        [XCTContext runActivityNamed:titles[i] block:^(id<XCTActivity>  _Nonnull activity) {
             [elements[i] tap];
-                                   
+
             // XCTest waits for the app to idle before continuing.
 
-           // Tap 'Back' button.
-           [app.navigationBars.buttons.allElementsBoundByIndex.firstObject tap];
+            // Tap 'Back' button.
+            [app.navigationBars.buttons.allElementsBoundByIndex.firstObject tap];
         }];
     }
 }

--- a/ExamplesUITests/ExamplesUITests.m
+++ b/ExamplesUITests/ExamplesUITests.m
@@ -31,6 +31,23 @@
     [super tearDown];
 }
 
+- (void)testAnimatedLineExample {
+
+    [XCTContext runActivityNamed:@"AnimatedLineExample"
+                           block:^(id<XCTActivity>  _Nonnull activity) {
+
+                               XCUIApplication *app = [[XCUIApplication alloc] init];
+                               [app.tables.staticTexts[@"AnimatedLineExample"] tap];
+
+                               // Wait for notification
+                               XCTDarwinNotificationExpectation *expectation = [[XCTDarwinNotificationExpectation alloc] initWithNotificationName:@"com.mapbox.examples.example-complete"];
+
+                               [self waitForExpectations:@[expectation] timeout:30.0];
+
+                               [app.navigationBars[@"AnimatedLineExample"].buttons[@"Examples"] tap];
+                           }];
+}
+
 - (void)testEveryExample {
     XCUIApplication *app = [[XCUIApplication alloc] init];
 

--- a/ExamplesUITests/ExamplesUITests.m
+++ b/ExamplesUITests/ExamplesUITests.m
@@ -11,7 +11,7 @@
 #import "TestingSupport.h"
 
 @interface ExamplesUITests : XCTestCase
-
+@property (nonatomic) XCUIApplication *app;
 @end
 
 @implementation ExamplesUITests
@@ -23,9 +23,11 @@
     self.continueAfterFailure = NO;
 
     // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
-    XCUIApplication *app = [[XCUIApplication alloc] init];
-    app.launchArguments = [app.launchArguments arrayByAddingObject:@"useFastAnimations"];
-    [app launch];
+    self.app = [[XCUIApplication alloc] init];
+    self.app.launchArguments = [self.app.launchArguments arrayByAddingObject:@"useFastAnimations"];
+    [self.app launch];
+
+    [self.app.navigationBars[@"Examples"].buttons[@"ObjC"] tap];
 }
 
 - (void)tearDown {
@@ -38,16 +40,14 @@
  */
 - (void)testAnimatedLineExample {
 
-    XCUIApplication *app = [[XCUIApplication alloc] init];
-
     [XCTContext runActivityNamed:@"AnimatedLineExample" block:^(id<XCTActivity>  _Nonnull activity) {
-        [app.tables.staticTexts[@"Animate a line"] tap];
+        [self.app.tables.staticTexts[@"Animate a line"] tap];
 
         // Wait for notification
         XCTDarwinNotificationExpectation *expectation = [[XCTDarwinNotificationExpectation alloc] initWithNotificationName:MBXTestingSupportNotificationExampleComplete];
         [self waitForExpectations:@[expectation] timeout:30.0];
 
-        [app.navigationBars[@"AnimatedLineExample"].buttons[@"Examples"] tap];
+        [self.app.navigationBars[@"AnimatedLineExample"].buttons[@"Examples"] tap];
     }];
 }
 
@@ -56,14 +56,13 @@
  Zoom and rotate the map.
  */
 - (void)testCustomAnnotationView {
-    XCUIApplication *app = [[XCUIApplication alloc] init];
 
     __block XCUIElement *element;
     __block XCUIElement *compass;
 
     [XCTContext runActivityNamed:@"Wait for initial render" block:^(id<XCTActivity>  _Nonnull activity) {
-        [app.tables.staticTexts[@"Annotation views"] tap];
-        XCUIElementQuery *allQuery = [app descendantsMatchingType:XCUIElementTypeAny];
+        [self.app.tables.staticTexts[@"Annotation views"] tap];
+        XCUIElementQuery *allQuery = [self.app descendantsMatchingType:XCUIElementTypeAny];
         element = [allQuery elementMatchingType:XCUIElementTypeAny identifier:@"MGLMapViewId"];
         compass = [allQuery elementMatchingType:XCUIElementTypeAny identifier:@"MGLMapViewCompassId"];
 
@@ -88,19 +87,17 @@
         XCTestExpectation *expectation = [self expectationWithDescription:@"wait"];
         (void)[XCTWaiter waitForExpectations:@[expectation] timeout:3.0]; // Let it timeout
 
-        [app.navigationBars[@"AnnotationViewExample"].buttons[@"Examples"] tap];
+        [self.app.navigationBars[@"AnnotationViewExample"].buttons[@"Examples"] tap];
     }];
 }
 
 - (void)testBuildingLightExample {
-    XCUIApplication *app = [[XCUIApplication alloc] init];
-
     __block XCUIElement *element;
     __block XCUIElement *slider;
 
     [XCTContext runActivityNamed:@"Wait for initial render" block:^(id<XCTActivity>  _Nonnull activity) {
-        [app.tables.staticTexts[@"Adjust lighting of 3D buildings"] tap];
-        XCUIElementQuery *allQuery = [app descendantsMatchingType:XCUIElementTypeAny];
+        [self.app.tables.staticTexts[@"Adjust lighting of 3D buildings"] tap];
+        XCUIElementQuery *allQuery = [self.app descendantsMatchingType:XCUIElementTypeAny];
         element = [allQuery elementMatchingType:XCUIElementTypeAny identifier:@"MGLMapViewId"];
         slider = [allQuery elementMatchingType:XCUIElementTypeSlider identifier:@"SliderId"];
 
@@ -114,12 +111,11 @@
         [slider adjustToNormalizedSliderPosition:0.5];
     }];
 
-    [app.navigationBars[@"BuildingLightExample"].buttons[@"Examples"] tap];
+    [self.app.navigationBars[@"BuildingLightExample"].buttons[@"Examples"] tap];
 }
 
 
 - (void)testEveryExample {
-    XCUIApplication *app = [[XCUIApplication alloc] init];
 
     __block NSUInteger count;
     __block NSMutableArray<XCUIElement*> *elements;
@@ -129,7 +125,7 @@
     // activities)
     [XCTContext runActivityNamed:@"Get examples" block:^(id<XCTActivity>  _Nonnull activity) {
 
-        XCUIElementQuery *cells = app.tables.cells;
+        XCUIElementQuery *cells = self.app.tables.cells;
         count = cells.count;
 
         elements = [NSMutableArray arrayWithCapacity:count];
@@ -137,7 +133,7 @@
 
         for (int i = 0; i < count; i++) {
             XCUIElement *el = cells.allElementsBoundByIndex[i];
-            NSString *title = [[el.staticTexts element] label];
+            NSString *title = [[el.staticTexts element].firstMatch label];
 
             [elements addObject:el];
             [titles addObject:title];
@@ -151,7 +147,7 @@
             // XCTest waits for the app to idle before continuing.
 
             // Tap 'Back' button.
-            [app.navigationBars.buttons.allElementsBoundByIndex.firstObject tap];
+            [self.app.navigationBars.buttons.allElementsBoundByIndex.firstObject tap];
         }];
     }
 }

--- a/ExamplesUITests/ExamplesUITests.m
+++ b/ExamplesUITests/ExamplesUITests.m
@@ -41,7 +41,7 @@
     XCUIApplication *app = [[XCUIApplication alloc] init];
 
     [XCTContext runActivityNamed:@"AnimatedLineExample" block:^(id<XCTActivity>  _Nonnull activity) {
-        [app.tables.staticTexts[@"AnimatedLineExample"] tap];
+        [app.tables.staticTexts[@"Animate a line"] tap];
 
         // Wait for notification
         XCTDarwinNotificationExpectation *expectation = [[XCTDarwinNotificationExpectation alloc] initWithNotificationName:MBXTestingSupportNotificationExampleComplete];
@@ -62,7 +62,7 @@
     __block XCUIElement *compass;
 
     [XCTContext runActivityNamed:@"Wait for initial render" block:^(id<XCTActivity>  _Nonnull activity) {
-        [app.tables.staticTexts[@"AnnotationViewExample"] tap];
+        [app.tables.staticTexts[@"Annotation views"] tap];
         XCUIElementQuery *allQuery = [app descendantsMatchingType:XCUIElementTypeAny];
         element = [allQuery elementMatchingType:XCUIElementTypeAny identifier:@"MGLMapViewId"];
         compass = [allQuery elementMatchingType:XCUIElementTypeAny identifier:@"MGLMapViewCompassId"];
@@ -72,11 +72,13 @@
     }];
 
     [XCTContext runActivityNamed:@"Pinch & Rotate" block:^(id<XCTActivity>  _Nonnull activity) {
-        [element pinchWithScale:2 velocity:10.0];
+        [element pinchWithScale:3 velocity:10.0];
         [element rotate:M_PI*0.75 withVelocity:M_PI*0.75]; // should take 1 second
-        [element pinchWithScale:0.20 velocity:-10.0];
+        [element pinchWithScale:0.2 velocity:-10.0];
 
         [compass tap];
+
+        [element pinchWithScale:0.2 velocity:-10.0];
     }];
 
     // TODO: Check orientation & shape of annotations.
@@ -97,7 +99,7 @@
     __block XCUIElement *slider;
 
     [XCTContext runActivityNamed:@"Wait for initial render" block:^(id<XCTActivity>  _Nonnull activity) {
-        [app.tables.staticTexts[@"BuildingLightExample"] tap];
+        [app.tables.staticTexts[@"Adjust lighting of 3D buildings"] tap];
         XCUIElementQuery *allQuery = [app descendantsMatchingType:XCUIElementTypeAny];
         element = [allQuery elementMatchingType:XCUIElementTypeAny identifier:@"MGLMapViewId"];
         slider = [allQuery elementMatchingType:XCUIElementTypeSlider identifier:@"SliderId"];

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
-  - Mapbox-iOS-SDK (4.0.1)
+  - Mapbox-iOS-SDK (4.1.0)
   - MapboxCoreNavigation (0.17.0-beta.1):
     - MapboxDirections.swift (~> 0.20.0)
     - MapboxMobileEvents (~> 0.4)
     - Turf (~> 0.1)
   - MapboxDirections.swift (0.20.0):
     - Polyline (~> 4.2)
-  - MapboxMobileEvents (0.4.0)
+  - MapboxMobileEvents (0.4.1)
   - MapboxNavigation (0.17.0-beta.1):
     - Mapbox-iOS-SDK (~> 4.0)
     - MapboxCoreNavigation (= 0.17.0-beta.1)
@@ -15,10 +15,10 @@ PODS:
   - MapboxSpeech (0.0.1)
   - Polyline (4.2.0)
   - Solar (2.1.0)
-  - Turf (0.1.1)
+  - Turf (0.2.0)
 
 DEPENDENCIES:
-  - Mapbox-iOS-SDK (~> 4.0.0)
+  - Mapbox-iOS-SDK (~> 4.1.0)
   - MapboxCoreNavigation (from `https://raw.githubusercontent.com/mapbox/mapbox-navigation-ios/v0.17.0-beta.1/MapboxCoreNavigation.podspec`)
   - MapboxNavigation (from `https://raw.githubusercontent.com/mapbox/mapbox-navigation-ios/v0.17.0-beta.1/MapboxNavigation.podspec`)
 
@@ -39,16 +39,16 @@ EXTERNAL SOURCES:
     :podspec: https://raw.githubusercontent.com/mapbox/mapbox-navigation-ios/v0.17.0-beta.1/MapboxNavigation.podspec
 
 SPEC CHECKSUMS:
-  Mapbox-iOS-SDK: 09b978be732d753e5c5e2911460fc0a018ce9be6
+  Mapbox-iOS-SDK: f0a9813d5f08c096c1199eceb57ec6102b19cf54
   MapboxCoreNavigation: 2f84ea58a6dd555b278994c750981e32ed4cb2a9
   MapboxDirections.swift: 9a46ca0f0608c76393f392ae793459cc30aa846f
-  MapboxMobileEvents: e71cf788a95fa0c01ad6ce17fd5efd13140af5ff
+  MapboxMobileEvents: c198687e2ce67b1a98bd504c260aef35ace78ae2
   MapboxNavigation: d75ec22bfdf6946bf8f791e941cfeccd5c745945
   MapboxSpeech: 6cc9b3d53adc2988af3ebc704dd17907b84a3f9f
   Polyline: 3d69f75bb136357e27291d439d0436c6ebda57a4
   Solar: 2dc6e7cc39186cb0c8228fa08df76fb50c7d8f24
-  Turf: 4ace207379c8d58a8e45842755de821dac3fae72
+  Turf: 65817136031583da7ea2b43e6611dd10ddbdab2f
 
-PODFILE CHECKSUM: 3121d6b2eb4dc288551d5a9283c5a66e08b11c2e
+PODFILE CHECKSUM: 0ca5db1d3fcba1b4da2e5a821bfd9050313a7352
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
In the following PR:
- I've tried to leave the examples untouched; any test related code is in an associated category.
- Communication to the host test is via notifications (or existence of UI elements, but non of these tests do that). To handle this, this code inserts a forwarding delegate to manage posting notifications.
- One issue is that this delegate is inserted in `viewWillAppear` implemented in the category - this is fine right now, as NONE of the examples currently implement it. But ideally there would be a better way to manage this. Thoughts?
- This just uses XCUITests, without any 3rd party dependencies. Ideally, we'd keep it like this.
- I rejigged the `testEveryExample` test to use `XCTActivity` so that the test report shows a clean list of tests. It means the implementation is a little convoluted, but results in a cleaner log.

Thoughts?

/cc @akitchen 