### PR TITLE
Add swift entry and show class name

### DIFF
--- a/Examples/Examples.m
+++ b/Examples/Examples.m
@@ -109,9 +109,11 @@
             NSString *swiftName = [NSString stringWithFormat:@"%@_Swift", objcName];
             NSString *title = example[@"title"] ? example[@"title"] : example[@"className"];
             
+            NSAssert(NSClassFromString(objcName) != nil, ([NSString stringWithFormat:@"The class %@ does not exist", objcName]));
             [objcExamples addObject:@{@"className": objcName,
                                       @"title": title
                                       }];
+            NSAssert(NSClassFromString(swiftName) != nil, ([NSString stringWithFormat:@"The class %@ does not exist", swiftName]));
             [swiftExamples addObject:@{@"className": swiftName,
                                        @"title": title
                                        }];

--- a/Examples/Examples.m
+++ b/Examples/Examples.m
@@ -123,7 +123,7 @@
                                     }];
         [swifCategories addObject:@{
                                     @"title": category[@"title"],
-                                    @"examples": objcExamples
+                                    @"examples": swiftExamples
                                     }];
     }];
     

--- a/Examples/ExamplesTableViewController.m
+++ b/Examples/ExamplesTableViewController.m
@@ -90,6 +90,7 @@ NSString *const MBXSegueTableToExample = @"TableToExampleSegue";
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"ExampleCell" forIndexPath:indexPath];
     
     cell.textLabel.text = [self exampleAtIndexPath:indexPath][@"title"];
+    cell.detailTextLabel.text = [self exampleAtIndexPath:indexPath][@"className"];
     
     return cell;
 }

--- a/Examples/Main.storyboard
+++ b/Examples/Main.storyboard
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="ExampleCell" textLabel="2OV-ag-M78" style="IBUITableViewCellStyleDefault" id="uOq-7b-YXm">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="ExampleCell" textLabel="2OV-ag-M78" detailTextLabel="4MT-rt-T23" style="IBUITableViewCellStyleSubtitle" id="uOq-7b-YXm">
                                 <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="uOq-7b-YXm" id="Y0e-IA-9M7">
@@ -26,10 +26,17 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="2OV-ag-M78">
-                                            <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                            <rect key="frame" x="16" y="5" width="33.5" height="20.5"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="4MT-rt-T23">
+                                            <rect key="frame" x="16" y="25.5" width="44" height="14.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                            <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -83,7 +90,6 @@
         <!--Navigation Controller-->
         <scene sceneID="NqE-wE-f7O">
             <objects>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="SiO-Mn-QjY" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <navigationController id="icM-J6-7Ve" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="62O-Wd-YC9">
                         <rect key="frame" x="0.0" y="20" width="375" height="44"/>
@@ -93,6 +99,7 @@
                         <segue destination="rYw-fr-DVv" kind="relationship" relationship="rootViewController" id="p4h-0g-frx"/>
                     </connections>
                 </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="SiO-Mn-QjY" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-700" y="280"/>
         </scene>


### PR DESCRIPTION
Fixes https://github.com/mapbox/ios-sdk-examples/issues/179, also I made some improvements:

1. Added asserts to make sure we can find the class of examples does not exist during development.
2. Show the class name fo examples on subtitle label, so that developers could easily find the corresponding class.
