### PR TITLE
Add enlarge annotation example

### DIFF
--- a/Examples/ObjectiveC/AnnotationViewExample.m
+++ b/Examples/ObjectiveC/AnnotationViewExample.m
@@ -108,7 +108,7 @@ NSString *const MBXExampleAnnotationView = @"AnnotationViewExample";
 
 // Adjust the positioning of the callout view once the annotation is selected.
 - (void)mapView:(MGLMapView *)mapView didSelectAnnotation:(id<MGLAnnotation>)annotation {
-    [mapView layoutSubviews];
+    [mapView setNeedsLayout];
 }
 
 @end

--- a/Examples/ObjectiveC/AnnotationViewExample.m
+++ b/Examples/ObjectiveC/AnnotationViewExample.m
@@ -21,11 +21,14 @@ NSString *const MBXExampleAnnotationView = @"AnnotationViewExample";
 - (void)setSelected:(BOOL)selected animated:(BOOL)animated {
     [super setSelected:selected animated:animated];
 
-    // Animate the border width in/out, creating an iris effect.
-    CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"borderWidth"];
-    animation.duration = 0.1;
-    self.layer.borderWidth = selected ? self.bounds.size.width / 4 : 2;
-    [self.layer addAnimation:animation forKey:@"borderWidth"];
+    // Increase the size of the annotation if it is selected, and restore annotation to its original size if it is not selected.
+    CABasicAnimation *animation = [CABasicAnimation animationWithKeyPath:@"bounds.size"];
+    [self.layer addAnimation:animation forKey:@"bounds.size"];
+    if (selected) {
+        [self.layer setAffineTransform:CGAffineTransformMakeScale(2, 2)];
+    } else {
+        [self.layer setAffineTransform:CGAffineTransformMakeScale(1, 1)];
+    }
 }
 
 @end
@@ -101,6 +104,11 @@ NSString *const MBXExampleAnnotationView = @"AnnotationViewExample";
 
 - (BOOL)mapView:(MGLMapView *)mapView annotationCanShowCallout:(id<MGLAnnotation>)annotation {
     return YES;
+}
+
+// Adjust the positioning of the callout view once the annotation is selected.
+- (void)mapView:(MGLMapView *)mapView didSelectAnnotation:(id<MGLAnnotation>)annotation {
+    [mapView layoutSubviews];
 }
 
 @end

--- a/Examples/Swift/AnnotationViewExample.swift
+++ b/Examples/Swift/AnnotationViewExample.swift
@@ -68,10 +68,11 @@ class AnnotationViewExample_Swift: UIViewController, MGLMapViewDelegate {
         return true
     }
     
+    // Adjust the positioning of the callout view once the annotation is selected.
     func mapView(_ mapView: MGLMapView, didSelect annotation: MGLAnnotation) {
-        let annot = pointAnnotations.filter { $0.coordinate.longitude == annotation.coordinate.longitude }
-        
+        mapView.layoutSubviews()
     }
+    
 }
 
 //
@@ -84,36 +85,21 @@ class CustomAnnotationView: MGLAnnotationView {
         layer.cornerRadius = bounds.width / 2
         layer.borderWidth = 2
         layer.borderColor = UIColor.white.cgColor
-
+        
     }
     
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
         
-        // Animate the border width in/out, creating an iris effect.
-        
-        if #available(iOS 9.0, *) {
-            let animation = CASpringAnimation(keyPath: "bounds.size")
-            setupAnimation(animation: animation, selected: selected)
-        } else {
-            let animation = CABasicAnimation(keyPath: "bounds.size")
-            setupAnimation(animation: animation, selected: selected)
-        }
-        
-    }
-    
-    func setupAnimation(animation: CABasicAnimation, selected: Bool) {
-                animation.duration = 0.1
-                animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
-            layer.add(animation, forKey: "bounds.size")
+        // Increase the size of the annotation if it is selected, and restore annotation to its original size if it is not selected.
+        let animation = CABasicAnimation(keyPath: "bounds.size")
+        animation.duration = 0.1
+        layer.add(animation, forKey: "bounds.size")
         if selected {
             layer.setAffineTransform(CGAffineTransform(scaleX: 2, y: 2))
         } else {
             layer.setAffineTransform(CGAffineTransform(scaleX: 1, y: 1))
         }
-//            layer.bounds.size.width = selected ? bounds.width * 2 : 40
-//                layer.bounds.size.height = selected ? bounds.height * 2 : 40
-//                layer.cornerRadius = bounds.width / 2
-//        layoutSubviews()
+        
     }
 }

--- a/Examples/Swift/AnnotationViewExample.swift
+++ b/Examples/Swift/AnnotationViewExample.swift
@@ -4,9 +4,10 @@ import Mapbox
 
 // Example view controller
 class AnnotationViewExample_Swift: UIViewController, MGLMapViewDelegate {
+    var pointAnnotations : [MGLPointAnnotation]!
     override func viewDidLoad() {
         super.viewDidLoad()
-    
+        
         let mapView = MGLMapView(frame: view.bounds)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.styleURL = MGLStyle.darkStyleURL
@@ -21,10 +22,10 @@ class AnnotationViewExample_Swift: UIViewController, MGLMapViewDelegate {
             CLLocationCoordinate2D(latitude: 0, longitude: 33),
             CLLocationCoordinate2D(latitude: 0, longitude: 66),
             CLLocationCoordinate2D(latitude: 0, longitude: 99),
-        ]
+            ]
         
         // Fill an array with point annotations and add it to the map.
-        var pointAnnotations = [MGLPointAnnotation]()
+        pointAnnotations = [MGLPointAnnotation]()
         for coordinate in coordinates {
             let point = MGLPointAnnotation()
             point.coordinate = coordinate
@@ -66,6 +67,11 @@ class AnnotationViewExample_Swift: UIViewController, MGLMapViewDelegate {
     func mapView(_ mapView: MGLMapView, annotationCanShowCallout annotation: MGLAnnotation) -> Bool {
         return true
     }
+    
+    func mapView(_ mapView: MGLMapView, didSelect annotation: MGLAnnotation) {
+        let annot = pointAnnotations.filter { $0.coordinate.longitude == annotation.coordinate.longitude }
+        
+    }
 }
 
 //
@@ -78,15 +84,36 @@ class CustomAnnotationView: MGLAnnotationView {
         layer.cornerRadius = bounds.width / 2
         layer.borderWidth = 2
         layer.borderColor = UIColor.white.cgColor
+
     }
     
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
         
         // Animate the border width in/out, creating an iris effect.
-        let animation = CABasicAnimation(keyPath: "borderWidth")
-        animation.duration = 0.1
-        layer.borderWidth = selected ? bounds.width / 4 : 2
-        layer.add(animation, forKey: "borderWidth")
+        
+        if #available(iOS 9.0, *) {
+            let animation = CASpringAnimation(keyPath: "bounds.size")
+            setupAnimation(animation: animation, selected: selected)
+        } else {
+            let animation = CABasicAnimation(keyPath: "bounds.size")
+            setupAnimation(animation: animation, selected: selected)
+        }
+        
+    }
+    
+    func setupAnimation(animation: CABasicAnimation, selected: Bool) {
+                animation.duration = 0.1
+                animation.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
+            layer.add(animation, forKey: "bounds.size")
+        if selected {
+            layer.setAffineTransform(CGAffineTransform(scaleX: 2, y: 2))
+        } else {
+            layer.setAffineTransform(CGAffineTransform(scaleX: 1, y: 1))
+        }
+//            layer.bounds.size.width = selected ? bounds.width * 2 : 40
+//                layer.bounds.size.height = selected ? bounds.height * 2 : 40
+//                layer.cornerRadius = bounds.width / 2
+//        layoutSubviews()
     }
 }

--- a/Examples/Swift/AnnotationViewExample.swift
+++ b/Examples/Swift/AnnotationViewExample.swift
@@ -70,7 +70,7 @@ class AnnotationViewExample_Swift: UIViewController, MGLMapViewDelegate {
     
     // Adjust the positioning of the callout view once the annotation is selected.
     func mapView(_ mapView: MGLMapView, didSelect annotation: MGLAnnotation) {
-        mapView.layoutSubviews()
+        mapView.setNeedsLayout()
     }
     
 }


### PR DESCRIPTION
I updated the annotation view example to scale the selected annotation. I ran into an issue where the positioning of the callout view is not updated based on the new size of the selected annotation. 


<img src ="https://user-images.githubusercontent.com/12474734/42192498-1cc29992-7e1e-11e8-9b9f-f71db2dc78a8.gif" width = 250>

My current workaround for this is to call `mapView.setNeedsLayout` in `mapView:didSelectAnnotation`.  It is a little jumpy, though. 


![2018-07-02 17_50_13](https://user-images.githubusercontent.com/12474734/42192900-81759932-7e20-11e8-849d-0b4c7fff49c9.gif)



Fixes #189 

cc @bsudekum 
