### PR TITLE
Update to maps SDK 4.4.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,8 @@ platform :ios, '9.0'
 use_frameworks!
 
 def shared_pods
-    pod 'Mapbox-iOS-SDK', '~> 4.3.0'
+	#pod 'Mapbox-iOS-SDK', '~> 4.3.0'
+    pod 'Mapbox-iOS-SDK', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.4.0-alpha.2/platform/ios/Mapbox-iOS-SDK.podspec'
     pod 'SwiftLint', '~> 0.26.0'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -2,8 +2,8 @@ platform :ios, '9.0'
 use_frameworks!
 
 def shared_pods
-	#pod 'Mapbox-iOS-SDK', '~> 4.3.0'
-    pod 'Mapbox-iOS-SDK', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.4.0-alpha.2/platform/ios/Mapbox-iOS-SDK.podspec'
+    #pod 'Mapbox-iOS-SDK', '~> 4.3.0'
+    pod 'Mapbox-iOS-SDK', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.4.0-beta.1/platform/ios/Mapbox-iOS-SDK.podspec'
     pod 'SwiftLint', '~> 0.26.0'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ use_frameworks!
 
 def shared_pods
     #pod 'Mapbox-iOS-SDK', '~> 4.3.0'
-    pod 'Mapbox-iOS-SDK', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.4.0-beta.1/platform/ios/Mapbox-iOS-SDK.podspec'
+    pod 'Mapbox-iOS-SDK', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.4.1/platform/ios/Mapbox-iOS-SDK.podspec'
     pod 'SwiftLint', '~> 0.26.0'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Mapbox-iOS-SDK (4.4.0-alpha.2)
+  - Mapbox-iOS-SDK (4.4.0-beta.1)
   - MapboxCoreNavigation (0.20.0):
     - MapboxDirections.swift (~> 0.22.0)
     - MapboxMobileEvents (~> 0.4)
@@ -19,7 +19,7 @@ PODS:
   - Turf (0.2.0)
 
 DEPENDENCIES:
-  - Mapbox-iOS-SDK (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.4.0-alpha.2/platform/ios/Mapbox-iOS-SDK.podspec`)
+  - Mapbox-iOS-SDK (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.4.0-beta.1/platform/ios/Mapbox-iOS-SDK.podspec`)
   - MapboxNavigation (~> 0.20.0)
   - SwiftLint (~> 0.26.0)
 
@@ -37,10 +37,10 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Mapbox-iOS-SDK:
-    :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.4.0-alpha.2/platform/ios/Mapbox-iOS-SDK.podspec
+    :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.4.0-beta.1/platform/ios/Mapbox-iOS-SDK.podspec
 
 SPEC CHECKSUMS:
-  Mapbox-iOS-SDK: d07ed1384273a96f9bce5d9e1db2e9550b9e5b84
+  Mapbox-iOS-SDK: 3c5289ab07d617073fee9ecf5c979895fa23ce66
   MapboxCoreNavigation: 5e742d0081da3ae51f2489ff98bfa1f28d2593b1
   MapboxDirections.swift: 67da008c3bff72ab68b0fc166185eebda23303be
   MapboxMobileEvents: e4aa629e4e2e3c250b5dadc15b63d67b91469a79
@@ -51,6 +51,6 @@ SPEC CHECKSUMS:
   SwiftLint: f6b83e8d95ee1e91e11932d843af4fdcbf3fc764
   Turf: 65817136031583da7ea2b43e6611dd10ddbdab2f
 
-PODFILE CHECKSUM: 180998ff1aa485077d9dcfa6af7b324f35c196f6
+PODFILE CHECKSUM: 6c72bbfdd4373c4524c4c3924f09c4f2bdd4f01f
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Mapbox-iOS-SDK (4.4.0-beta.1)
+  - Mapbox-iOS-SDK (4.4.1)
   - MapboxCoreNavigation (0.20.0):
     - MapboxDirections.swift (~> 0.22.0)
     - MapboxMobileEvents (~> 0.4)
@@ -19,7 +19,7 @@ PODS:
   - Turf (0.2.0)
 
 DEPENDENCIES:
-  - Mapbox-iOS-SDK (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.4.0-beta.1/platform/ios/Mapbox-iOS-SDK.podspec`)
+  - Mapbox-iOS-SDK (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.4.1/platform/ios/Mapbox-iOS-SDK.podspec`)
   - MapboxNavigation (~> 0.20.0)
   - SwiftLint (~> 0.26.0)
 
@@ -37,10 +37,10 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Mapbox-iOS-SDK:
-    :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.4.0-beta.1/platform/ios/Mapbox-iOS-SDK.podspec
+    :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.4.1/platform/ios/Mapbox-iOS-SDK.podspec
 
 SPEC CHECKSUMS:
-  Mapbox-iOS-SDK: 3c5289ab07d617073fee9ecf5c979895fa23ce66
+  Mapbox-iOS-SDK: e6a4f236c77f914ca2e19b929c6cc6b077ba1c4c
   MapboxCoreNavigation: 5e742d0081da3ae51f2489ff98bfa1f28d2593b1
   MapboxDirections.swift: 67da008c3bff72ab68b0fc166185eebda23303be
   MapboxMobileEvents: e4aa629e4e2e3c250b5dadc15b63d67b91469a79
@@ -51,6 +51,6 @@ SPEC CHECKSUMS:
   SwiftLint: f6b83e8d95ee1e91e11932d843af4fdcbf3fc764
   Turf: 65817136031583da7ea2b43e6611dd10ddbdab2f
 
-PODFILE CHECKSUM: 6c72bbfdd4373c4524c4c3924f09c4f2bdd4f01f
+PODFILE CHECKSUM: 558a8d8444fe94ea211f43eb0b7f23fa7dc95afa
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Mapbox-iOS-SDK (4.3.0)
+  - Mapbox-iOS-SDK (4.4.0-alpha.2)
   - MapboxCoreNavigation (0.20.0):
     - MapboxDirections.swift (~> 0.22.0)
     - MapboxMobileEvents (~> 0.4)
@@ -19,13 +19,12 @@ PODS:
   - Turf (0.2.0)
 
 DEPENDENCIES:
-  - Mapbox-iOS-SDK (~> 4.3.0)
+  - Mapbox-iOS-SDK (from `https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.4.0-alpha.2/platform/ios/Mapbox-iOS-SDK.podspec`)
   - MapboxNavigation (~> 0.20.0)
   - SwiftLint (~> 0.26.0)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
-    - Mapbox-iOS-SDK
     - MapboxCoreNavigation
     - MapboxDirections.swift
     - MapboxMobileEvents
@@ -36,8 +35,12 @@ SPEC REPOS:
     - SwiftLint
     - Turf
 
+EXTERNAL SOURCES:
+  Mapbox-iOS-SDK:
+    :podspec: https://raw.githubusercontent.com/mapbox/mapbox-gl-native/ios-v4.4.0-alpha.2/platform/ios/Mapbox-iOS-SDK.podspec
+
 SPEC CHECKSUMS:
-  Mapbox-iOS-SDK: 7d8d510088ba7900d11aa3ceb98f563b040efca1
+  Mapbox-iOS-SDK: d07ed1384273a96f9bce5d9e1db2e9550b9e5b84
   MapboxCoreNavigation: 5e742d0081da3ae51f2489ff98bfa1f28d2593b1
   MapboxDirections.swift: 67da008c3bff72ab68b0fc166185eebda23303be
   MapboxMobileEvents: e4aa629e4e2e3c250b5dadc15b63d67b91469a79
@@ -48,6 +51,6 @@ SPEC CHECKSUMS:
   SwiftLint: f6b83e8d95ee1e91e11932d843af4fdcbf3fc764
   Turf: 65817136031583da7ea2b43e6611dd10ddbdab2f
 
-PODFILE CHECKSUM: 379a32cf63ac07c6f40ed51673243048614c9cf9
+PODFILE CHECKSUM: 180998ff1aa485077d9dcfa6af7b324f35c196f6
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
A branch to test `ios-v4.4.0` pre-releases in (and eventually merge, after we’re finished).

/cc @mapbox/maps-ios 