### PR TITLE
Improve UISegment control style and layout for SwitchStyles example

### DIFF
--- a/Examples/ObjectiveC/SwitchStylesExample.m
+++ b/Examples/ObjectiveC/SwitchStylesExample.m
@@ -25,8 +25,12 @@ NSString *const MBXExampleSwitchStyles = @"SwitchStylesExample";
     [self.view addSubview:self.mapView];
     
     // Create a UISegmentedControl to toggle between map styles
-    UISegmentedControl *styleToggle =[[UISegmentedControl alloc] initWithItems:@[@"Dark", @"Streets", @"Light"]];
+    UISegmentedControl *styleToggle =[[UISegmentedControl alloc] initWithItems:@[@"Satellite", @"Streets", @"Light"]];
     styleToggle.translatesAutoresizingMaskIntoConstraints = NO;
+    styleToggle.tintColor = [UIColor colorWithRed:0.976 green:0.843 blue:0.831 alpha:1];
+    styleToggle.backgroundColor = [UIColor colorWithRed:0.973 green:0.329 blue:0.294 alpha:1];
+    styleToggle.layer.cornerRadius = 4;
+    styleToggle.clipsToBounds = YES;
     styleToggle.selectedSegmentIndex = 1;
     [self.view insertSubview:styleToggle aboveSubview:self.mapView];
     [styleToggle addTarget:self action:@selector(changeStyle:) forControlEvents:UIControlEventValueChanged];
@@ -34,8 +38,10 @@ NSString *const MBXExampleSwitchStyles = @"SwitchStylesExample";
     // Configure autolayout constraints for the UISegmentedControl to align
     // at the bottom of the map view and above the Mapbox logo and attribution
     NSMutableArray *constraints = [NSMutableArray array];
-    [constraints addObjectsFromArray:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-40-[styleToggle]-40-|" options:0 metrics:0 views:@{@"styleToggle":styleToggle}]];
+
+    [constraints addObject:[NSLayoutConstraint constraintWithItem:styleToggle attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:self.mapView attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:1.0]];
     [constraints addObject:[NSLayoutConstraint constraintWithItem:styleToggle attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:self.mapView.logoView attribute:NSLayoutAttributeTop multiplier:1 constant:-20]];
+    
     [self.view addConstraints:constraints];
 }
 
@@ -43,7 +49,7 @@ NSString *const MBXExampleSwitchStyles = @"SwitchStylesExample";
 - (void)changeStyle:(UISegmentedControl *)sender {
     switch(sender.selectedSegmentIndex){
         case 0:
-            self.mapView.styleURL = [MGLStyle darkStyleURL];
+            self.mapView.styleURL = [MGLStyle satelliteStyleURL];
             break;
         case 1:
             self.mapView.styleURL = [MGLStyle streetsStyleURL];

--- a/Examples/Swift/SwitchStylesExample.swift
+++ b/Examples/Swift/SwitchStylesExample.swift
@@ -19,15 +19,19 @@ class SwitchStylesExample: UIViewController {
         view.addSubview(mapView)
 
         // Create a UISegmentedControl to toggle between map styles
-        let styleToggle = UISegmentedControl(items: ["Dark", "Streets", "Light"])
+        let styleToggle = UISegmentedControl(items: ["Satellite", "Streets", "Light"])
         styleToggle.translatesAutoresizingMaskIntoConstraints = false
+        styleToggle.tintColor = UIColor(red: 0.976, green: 0.843, blue: 0.831, alpha: 1)
+        styleToggle.backgroundColor = UIColor(red: 0.973, green: 0.329, blue: 0.294, alpha: 1)
+        styleToggle.layer.cornerRadius = 4
+        styleToggle.clipsToBounds = true
         styleToggle.selectedSegmentIndex = 1
         view.insertSubview(styleToggle, aboveSubview: mapView)
         styleToggle.addTarget(self, action: #selector(changeStyle(sender:)), for: .valueChanged)
 
         // Configure autolayout constraints for the UISegmentedControl to align
         // at the bottom of the map view and above the Mapbox logo and attribution
-        NSLayoutConstraint.activate(NSLayoutConstraint.constraints(withVisualFormat: "H:|-40-[styleToggle]-40-|", options: [], metrics: nil, views: ["styleToggle": styleToggle]))
+        NSLayoutConstraint.activate([NSLayoutConstraint(item: styleToggle, attribute: NSLayoutAttribute.centerX, relatedBy: NSLayoutRelation.equal, toItem: mapView, attribute: NSLayoutAttribute.centerX, multiplier: 1.0, constant: 0.0)])
         NSLayoutConstraint.activate([NSLayoutConstraint(item: styleToggle, attribute: .bottom, relatedBy: .equal, toItem: mapView.logoView, attribute: .top, multiplier: 1, constant: -20)])
     }
 
@@ -35,7 +39,7 @@ class SwitchStylesExample: UIViewController {
     @objc func changeStyle(sender: UISegmentedControl) {
         switch sender.selectedSegmentIndex {
         case 0:
-            mapView.styleURL = MGLStyle.darkStyleURL
+            mapView.styleURL = MGLStyle.satelliteStyleURL
         case 1:
             mapView.styleURL = MGLStyle.streetsStyleURL
         case 2:


### PR DESCRIPTION
Closes https://github.com/mapbox/ios-sdk-examples/issues/210.

Notable changes:
- UISegmentedControl now has a background color and a tint color.
- Swapped Mapbox Dark for Satellite to better match with the color schemes of the other styles and colors used for the UISegmentedControl.
- Stopped resizing the UISegmentedControl when rotated.

Finding colors that matched yet contrasted enough was difficult for my non-designer self, so suggestions welcome. I would have liked to customize only the text color of each UISegment label but it doesn't seem there is a way to do this without introducing more complexity to the example.

<img height="500" src="https://user-images.githubusercontent.com/10850812/45247688-55558b00-b2be-11e8-993f-39f4aba43813.png">
