### PR TITLE
Run testEveryExample against both Obj-C and Swift again

### DIFF
--- a/Examples.xcodeproj/xcshareddata/xcschemes/Examples.xcscheme
+++ b/Examples.xcodeproj/xcshareddata/xcschemes/Examples.xcscheme
@@ -52,6 +52,17 @@
                BlueprintName = "ExamplesUITests"
                ReferencedContainer = "container:Examples.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "ExamplesUITests/testAnimatedLineExample">
+               </Test>
+               <Test
+                  Identifier = "ExamplesUITests/testBuildingLightExample">
+               </Test>
+               <Test
+                  Identifier = "ExamplesUITests/testCustomAnnotationView">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
       <MacroExpansion>


### PR DESCRIPTION
- Fixes #217 by ~splitting `testEveryExample` into `testEveryObjCExample` and `testEverySwiftExample`~ making `testEveryExample` run both Swift and Obj-C examples.
- Puts a bandaid over #221 by disabling the [flapping](https://app.bitrise.io/build/056f8df40469d0e3) ~`testAnimatedLineExample`~ individual tests.

/cc @mapbox/maps-ios 