### PR TITLE
ImageSourceExample: make objc/swift consistent; simplify

### DIFF
--- a/Examples/ObjectiveC/ImageSourceExample.m
+++ b/Examples/ObjectiveC/ImageSourceExample.m
@@ -5,7 +5,6 @@
 NSString *const MBXExampleImageSource = @"ImageSourceExample";
 
 @interface ImageSourceExample () <MGLMapViewDelegate>
-
 @end
 
 @implementation ImageSourceExample
@@ -16,6 +15,7 @@ NSString *const MBXExampleImageSource = @"ImageSourceExample";
     MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:[MGLStyle darkStyleURL]];
     [mapView setCenterCoordinate:CLLocationCoordinate2DMake(43.457, -75.789) zoomLevel:4 animated:NO];
     mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    mapView.tintColor = [UIColor darkGrayColor];
     
     // Set the map view‘s delegate property.
     mapView.delegate = self;
@@ -23,21 +23,23 @@ NSString *const MBXExampleImageSource = @"ImageSourceExample";
 }
 
 - (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {
-    
     // Set the coordinate bounds for the raster image.
     MGLCoordinateQuad coordinates = MGLCoordinateQuadMake(
-                                                          CLLocationCoordinate2DMake(46.437, -80.425),
-                                                          CLLocationCoordinate2DMake(37.936, -80.425),
-                                                          CLLocationCoordinate2DMake(37.936, -71.516),
-                                                          CLLocationCoordinate2DMake(46.437, -71.516));
+        CLLocationCoordinate2DMake(46.437, -80.425),
+        CLLocationCoordinate2DMake(37.936, -80.425),
+        CLLocationCoordinate2DMake(37.936, -71.516),
+        CLLocationCoordinate2DMake(46.437, -71.516)
+    );
     
-    // Create a MGLImageSource, which can be used to add georeferenced raster images to a map.
-    NSString *radarImage = [[NSBundle mainBundle] pathForResource:@"radar" ofType:@"gif"];
-    MGLImageSource *source = [[MGLImageSource alloc] initWithIdentifier:@"radar" coordinateQuad:coordinates image:[UIImage imageWithContentsOfFile:radarImage]];
+    // Create an MGLImageSource, used to add georeferenced raster images to a map.
+    UIImage *radarImage = [UIImage imageNamed:@"radar.gif"];
+    MGLImageSource *source = [[MGLImageSource alloc] initWithIdentifier:@"radar" coordinateQuad:coordinates image:radarImage];
     [style addSource:source];
-    
+
+    // Create a raster layer from the MGLImageSource.
     MGLRasterStyleLayer *radarLayer = [[MGLRasterStyleLayer alloc] initWithIdentifier:@"radar-layer" source:source];
-    
+
+    // Insert the raster layer below the map's symbol layers.
     for (MGLStyleLayer *layer in style.layers.reverseObjectEnumerator) {
         if (![layer isKindOfClass:[MGLSymbolStyleLayer class]]) {
             [style insertLayer:radarLayer aboveLayer:layer];

--- a/Examples/ObjectiveC/SatelliteStyleExample.m
+++ b/Examples/ObjectiveC/SatelliteStyleExample.m
@@ -8,7 +8,7 @@ NSString *const MBXExampleSatelliteStyle = @"SatelliteStyleExample";
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    // A hybrid style with unobtrusive labels is also available via +satelliteStreetsStyleURLWithVersion:.
+    // A hybrid style with unobtrusive labels is also available via +satelliteStreetsStyleURL.
     NSURL *styleURL = [MGLStyle satelliteStyleURL];
     MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL:styleURL];
 

--- a/Examples/Swift/ImageSourceExample.swift
+++ b/Examples/Swift/ImageSourceExample.swift
@@ -3,13 +3,13 @@ import Mapbox
 @objc(ImageSourceExample_Swift)
 
 class ImageSourceExample: UIViewController, MGLMapViewDelegate {
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
         let mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.darkStyleURL)
         mapView.setCenter(CLLocationCoordinate2D(latitude: 43.457, longitude: -75.789), zoomLevel: 4, animated: false)
         mapView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
+        mapView.tintColor = .darkGray
 
         // Set the map view‘s delegate property.
         mapView.delegate = self
@@ -24,15 +24,15 @@ class ImageSourceExample: UIViewController, MGLMapViewDelegate {
             bottomRight: CLLocationCoordinate2D(latitude: 37.936, longitude: -71.516),
             topRight: CLLocationCoordinate2D(latitude: 46.437, longitude: -71.516))
 
-        // Create a MGLImageSource, which can be used to add georeferenced raster images to a map.
-        if let radarImage = Bundle.main.path(forResource: "radar", ofType: "gif") {
-            let source = MGLImageSource(identifier: "radar", coordinateQuad: coordinates, image: UIImage(contentsOfFile: radarImage)!)
+        // Create an MGLImageSource, used to add georeferenced raster images to a map.
+        if let radarImage = UIImage(named: "radar.gif") {
+            let source = MGLImageSource(identifier: "radar", coordinateQuad: coordinates, image: radarImage)
             style.addSource(source)
 
             // Create a raster layer from the MGLImageSource.
             let radarLayer = MGLRasterStyleLayer(identifier: "radar-layer", source: source)
 
-            // Insert the image below the map's symbol layers.
+            // Insert the raster layer below the map's symbol layers.
             for layer in style.layers.reversed() {
                 if !layer.isKind(of: MGLSymbolStyleLayer.self) {
                     style.insertLayer(radarLayer, above: layer)

--- a/Examples/Swift/SatelliteStyleExample.swift
+++ b/Examples/Swift/SatelliteStyleExample.swift
@@ -8,7 +8,7 @@ class SatelliteStyleExample_Swift: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // A hybrid style with unobtrusive labels is also available via satelliteStreetsStyleURL(withVersion:).
+        // A hybrid style with unobtrusive labels is also available via satelliteStreetsStyleURL.
         mapView = MGLMapView(frame: view.bounds, styleURL: MGLStyle.satelliteStyleURL)
 
         // Tint the ℹ️ button.


### PR DESCRIPTION
Just some minor edits to `ImageSourceExample` and `SatelliteStyleExample` that occurred to me as I was researching another issue.

- Updates comments and keeps them consistent across objc/swift.
- Simplifies image loading.
- Removes some very deep indentation.

/cc @jmkiley @captainbarbosa 