### PR TITLE
Navigation SDK v0.25.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ target 'Examples' do
 end
 
 target 'DocsCode' do
-  pod 'MapboxNavigation', '~> 0.24.0'
+  pod 'MapboxNavigation', '~> 0.25.0'
   # pod 'MapboxCoreNavigation', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-navigation-ios/v0.17.0-beta.1/MapboxCoreNavigation.podspec'
   # pod 'MapboxNavigation', :podspec => 'https://raw.githubusercontent.com/mapbox/mapbox-navigation-ios/v0.17.0-beta.1/MapboxNavigation.podspec'
   shared_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,28 +1,28 @@
 PODS:
   - Mapbox-iOS-SDK (4.6.0)
-  - MapboxCoreNavigation (0.24.0):
-    - MapboxDirections.swift (~> 0.24.0)
+  - MapboxCoreNavigation (0.25.0):
+    - MapboxDirections.swift (~> 0.25.1)
     - MapboxMobileEvents (~> 0.6.0)
     - MapboxNavigationNative (~> 3.2.0)
     - Turf (~> 0.2.0)
-  - MapboxDirections.swift (0.24.1):
+  - MapboxDirections.swift (0.25.1):
     - Polyline (~> 4.2)
   - MapboxMobileEvents (0.6.0)
-  - MapboxNavigation (0.24.0):
+  - MapboxNavigation (0.25.0):
     - Mapbox-iOS-SDK (~> 4.3)
-    - MapboxCoreNavigation (= 0.24.0)
-    - MapboxSpeech (~> 0.0.1)
+    - MapboxCoreNavigation (= 0.25.0)
+    - MapboxSpeech (~> 0.1.0)
     - Solar (~> 2.1)
   - MapboxNavigationNative (3.2.0)
-  - MapboxSpeech (0.0.2)
+  - MapboxSpeech (0.1.0)
   - Polyline (4.2.0)
   - Solar (2.1.0)
-  - SwiftLint (0.27.0)
+  - SwiftLint (0.28.1)
   - Turf (0.2.1)
 
 DEPENDENCIES:
   - Mapbox-iOS-SDK (~> 4.6.0)
-  - MapboxNavigation (~> 0.24.0)
+  - MapboxNavigation (~> 0.25.0)
   - SwiftLint (~> 0.27)
 
 SPEC REPOS:
@@ -41,17 +41,17 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Mapbox-iOS-SDK: 204c04713477cf2a88c52c5a8eed1790eb75a02a
-  MapboxCoreNavigation: 5356139c9c79af60b59f287a89b98122934a0d2b
-  MapboxDirections.swift: 25ea07ca06a3c64c335dc8852f3c94fcabd443c8
+  MapboxCoreNavigation: e372e4db93ceee0ca6ac21bb654aecd323193080
+  MapboxDirections.swift: d08d40a6b50c13e1e83c165565b7aaec752eb087
   MapboxMobileEvents: 0218869f556a7fdac9f869e2f9c10e8c6dd7eed5
-  MapboxNavigation: fb07d00208dae19483c99f95aa46821f47fe409f
+  MapboxNavigation: 2b267765bb7d7145e7307bf2817818b661efa5de
   MapboxNavigationNative: 1173dc73d6643e321065cfaa55d253f67b55ab12
-  MapboxSpeech: 9d46bca4d7e96318ec8d6ce93a1153ebaef319ba
+  MapboxSpeech: d7569ee91dd8bdca3ef8d19b6828e8754c1073ec
   Polyline: 3d69f75bb136357e27291d439d0436c6ebda57a4
   Solar: 2dc6e7cc39186cb0c8228fa08df76fb50c7d8f24
-  SwiftLint: 3207c1faa2240bf8973b191820a116113cd11073
+  SwiftLint: 7f5f7de0da74a649b16616cb5246ae323489656e
   Turf: 9763a5a2d7da05dfdd5ed56aeb0414b291b0fee1
 
-PODFILE CHECKSUM: 6f1b378f6be274d28b9eac4a92e22daf3253d23e
+PODFILE CHECKSUM: 76e4ac0c30276b20b14e0b9f14fcf317af923083
 
 COCOAPODS: 1.6.0.beta.2


### PR DESCRIPTION
Upgraded to navigation SDK v0.25.0. Upgrading MapboxDirections.swift to v0.25._x_ produced some Objective-C compiler warnings, which are fixed in mapbox/MapboxDirections.swift#317.

/cc @frederoni