### PR TITLE
Enable code coverage, add code coverage & bitrise badges

### DIFF
--- a/Examples.xcodeproj/xcshareddata/xcschemes/Examples.xcscheme
+++ b/Examples.xcodeproj/xcshareddata/xcschemes/Examples.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Mapbox iOS SDK Examples
 
-A live Xcode project/app that provides [public examples](https://docs.mapbox.com/ios/maps/examples/) for the Mapbox Maps SDK for iOS.
+[![bitrise](https://app.bitrise.io/app/9a144f2169b7c9e3/status.svg?token=yzLGB24ubR_INs6HqUl14g&branch=master)](https://app.bitrise.io/app/9a144f2169b7c9e3#)[![codecov](https://codecov.io/gh/mapbox/ios-sdk-examples/branch/master/graph/badge.svg)](https://codecov.io/gh/mapbox/ios-sdk-examples)
+
+A live Xcode project/app that provides [public examples](https://www.mapbox.com/ios-sdk/examples/) for the Mapbox Maps SDK for iOS.
 
 ## How to receive help
 We are not able to answer support questions in this repository — it is intended to show examples of what is possible with the Mapbox Maps SDK for iOS.  If you have questions about how to use the Mapbox Maps SDK for iOS, please see our excellent [documentation](https://docs.mapbox.com/help/) or ask the community at [Stack Overflow](http://stackoverflow.com/questions/tagged/mapbox+ios).

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "ExamplesTests/"
+  - "ExamplesUITests/"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
 ignore:
   - "ExamplesTests/"
   - "ExamplesUITests/"
+  - "Examples/Testing Categories"


### PR DESCRIPTION
This adds a code coverage badge and enables code coverage on this repo. Currently ignores tests and the [Testing Categories](https://github.com/mapbox/ios-sdk-examples/tree/master/Examples/Testing%20Categories) when generating code coverage.