### PR TITLE
Updates cluster example for new cluster APIs

### DIFF
--- a/Examples/ObjectiveC/ClusteringExample.m
+++ b/Examples/ObjectiveC/ClusteringExample.m
@@ -24,7 +24,7 @@ NSString *const MBXExampleClustering = @"ClusteringExample";
     
     // Add a double tap gesture recognizer. This gesture is used for double
     // tapping on clusters and then zooming in so the cluster expands to its
-    // children
+    // children.
     UITapGestureRecognizer *doubleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleDoubleTapCluster:)];
     doubleTap.numberOfTapsRequired = 2;
     doubleTap.delegate = self;
@@ -43,7 +43,7 @@ NSString *const MBXExampleClustering = @"ClusteringExample";
     
     // Add a single tap gesture recognizer. This gesture requires the built-in
     // MGLMapView tap gestures (such as those for zoom and annotation selection)
-    // to fail. (This order differs from the double tap above.)
+    // to fail (this order differs from the double tap above).
     UITapGestureRecognizer *singleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleMapTap:)];
     for (UIGestureRecognizer *recognizer in self.mapView.gestureRecognizers) {
         if ([recognizer isKindOfClass:[UITapGestureRecognizer class]]) {
@@ -67,7 +67,8 @@ NSString *const MBXExampleClustering = @"ClusteringExample";
     // Use a template image so that we can tint it with the `iconColor` runtime styling property.
     [style setImage:[self.icon imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forName:@"icon"];
 
-    // Show unclustered features as icons. The `cluster` attribute is built into clustering-enabled source features.
+    // Show unclustered features as icons. The `cluster` attribute is built into clustering-enabled
+    // source features.
     MGLSymbolStyleLayer *ports = [[MGLSymbolStyleLayer alloc] initWithIdentifier:@"ports" source:source];
     ports.iconImageName = [NSExpression expressionForConstantValue:@"icon"];
     ports.iconColor = [NSExpression expressionForConstantValue:[[UIColor darkGrayColor] colorWithAlphaComponent:0.9]];
@@ -80,7 +81,8 @@ NSString *const MBXExampleClustering = @"ClusteringExample";
                              @100: [UIColor redColor],
                              @200: [UIColor purpleColor] };
     
-    // Show clustered features as circles. The `point_count` attribute is built into clustering-enabled source features.
+    // Show clustered features as circles. The `point_count` attribute is built into
+    // clustering-enabled source features.
     MGLCircleStyleLayer *circlesLayer = [[MGLCircleStyleLayer alloc] initWithIdentifier:@"clusteredPorts" source:source];
     circlesLayer.circleRadius = [NSExpression expressionForConstantValue:@(self.icon.size.width / 2)];
     circlesLayer.circleOpacity = [NSExpression expressionForConstantValue:@0.75];
@@ -91,7 +93,9 @@ NSString *const MBXExampleClustering = @"ClusteringExample";
     circlesLayer.predicate = [NSPredicate predicateWithFormat:@"cluster == YES"];
     [style addLayer:circlesLayer];
 
-    // Label cluster circles with a layer of text indicating feature count. The value for `point_count` is an integer. In order to use that value for the `MGLSymbolStyleLayer.text` property, cast it as a string. 
+    // Label cluster circles with a layer of text indicating feature count. The value for
+    // `point_count` is an integer. In order to use that value for the
+    // `MGLSymbolStyleLayer.text` property, cast it as a string.
     MGLSymbolStyleLayer *numbersLayer = [[MGLSymbolStyleLayer alloc] initWithIdentifier:@"clusteredPortsNumbers" source:source];
     numbersLayer.textColor = [NSExpression expressionForConstantValue:[UIColor whiteColor]];
     numbersLayer.textFontSize = [NSExpression expressionForConstantValue:@(self.icon.size.width / 2)];
@@ -111,8 +115,8 @@ NSString *const MBXExampleClustering = @"ClusteringExample";
     CGRect rect = CGRectMake(point.x - width / 2, point.y - width / 2, width, width);
 
     // This example shows how to check if a feature is a cluster by
-    // checking for that the feature is a `MGLPointFeatureCluster` (you could
-    // also check for conformance with `MGLCluster`)
+    // checking for that the feature is a `MGLPointFeatureCluster`. Alternatively, you could
+    // also check for conformance with `MGLCluster` instead.
     NSArray<id<MGLFeature>> *features = [self.mapView visibleFeaturesInRect:rect inStyleLayersWithIdentifiers:[NSSet setWithObjects:@"clusteredPorts", @"ports", nil]];
     
     NSPredicate *clusterPredicate = [NSPredicate predicateWithBlock:^BOOL(id  _Nullable evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
@@ -121,7 +125,8 @@ NSString *const MBXExampleClustering = @"ClusteringExample";
 
     NSArray *clusters = [features filteredArrayUsingPredicate:clusterPredicate];
 
-    // Pick the first cluster. Ideally this would pick the nearest cluster to the touch point
+    // Pick the first cluster, ideally selecting the one nearest nearest one to
+    // the touch point.
     return (MGLPointFeatureCluster *)clusters.firstObject;
 }
 
@@ -175,8 +180,8 @@ NSString *const MBXExampleClustering = @"ClusteringExample";
 
     NSArray<id<MGLFeature>> *features = [self.mapView visibleFeaturesInRect:rect inStyleLayersWithIdentifiers:[NSSet setWithObjects:@"clusteredPorts", @"ports", nil]];
     
-    // Pick the first feature (which could be a port or a cluster). Ideally this
-    // would pick the nearest feature to the touch point
+    // Pick the first feature (which may be a port or a cluster), ideally selecting
+    // the one nearest nearest one to the touch point.
     id<MGLFeature> feature = features.firstObject;
     
     if (!feature) {
@@ -187,7 +192,7 @@ NSString *const MBXExampleClustering = @"ClusteringExample";
     UIColor *color = UIColor.redColor;
     
     if ([feature isKindOfClass:[MGLPointFeatureCluster class]]) {
-        // Tapped on a cluster
+        // Tapped on a cluster.
         MGLPointFeatureCluster *cluster = (MGLPointFeatureCluster *)feature;
         
         NSArray *children = [(MGLShapeSource*)source childrenOfCluster:cluster];
@@ -196,7 +201,7 @@ NSString *const MBXExampleClustering = @"ClusteringExample";
                        children.count];
         color = UIColor.blueColor;
     } else {
-        // Tapped on a port
+        // Tapped on a port.
         id name = [feature attributeForKey:@"name"];
         if ([name isKindOfClass:[NSString class]]) {
             description = (NSString *)name;
@@ -227,7 +232,7 @@ NSString *const MBXExampleClustering = @"ClusteringExample";
 
     [popup sizeToFit];
     
-    // Expand
+    // Expand the popup.
     popup.bounds = CGRectInset(popup.bounds, -10, -10);
     CGPoint point = [self.mapView convertCoordinate:coordinate toPointToView:self.mapView];
     popup.center = CGPointMake(point.x, point.y - 50);

--- a/Examples/Swift/ClusteringExample.swift
+++ b/Examples/Swift/ClusteringExample.swift
@@ -83,10 +83,15 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
     }
 
     @objc @IBAction func handleMapTap(sender: UITapGestureRecognizer) throws {
-        guard sender.state == .ended else {
+        
+        guard let source = mapView.style?.source(withIdentifier: "clusteredPorts") as? MGLShapeSource else {
             return
         }
 
+        guard sender.state == .ended else {
+            return
+        }
+        
         showPopup(false, animated: false)
 
         let point = sender.location(in: sender.view)
@@ -112,9 +117,10 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
         let color: UIColor
 
         if let cluster = feature as? MGLCluster {
-            description = "Cluster with \(cluster.clusterPointCountAbbreviation) points"
+
+            let children = source.children(of: cluster)
+            description = "Cluster #\(cluster.clusterIdentifier)\n\(children.count) children\n\(cluster.clusterPointCountAbbreviation) points"
             color = .blue
-            cluster.debugDescription
         } else if let featureName = feature.attribute(forKey: "name") as? String?,
             let portName = featureName {
             description = portName
@@ -138,6 +144,7 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
         popup.layer.masksToBounds = true
         popup.textAlignment       = .center
         popup.lineBreakMode       = .byTruncatingTail
+        popup.numberOfLines       = 0
         popup.font                = .systemFont(ofSize: 16)
         popup.textColor           = textColor
         popup.alpha               = 0

--- a/Examples/Swift/ClusteringExample.swift
+++ b/Examples/Swift/ClusteringExample.swift
@@ -23,7 +23,7 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
 
         // Add a double tap gesture recognizer. This gesture is used for double
         // tapping on clusters and then zooming in so the cluster expands to its
-        // children
+        // children.
         let doubleTap = UITapGestureRecognizer(target: self, action: #selector(handleDoubleTapCluster(sender:)))
         doubleTap.numberOfTapsRequired = 2
         doubleTap.delegate = self
@@ -40,7 +40,7 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
 
         // Add a single tap gesture recognizer. This gesture requires the built-in
         // MGLMapView tap gestures (such as those for zoom and annotation selection)
-        // to fail. (This order differs from the double tap above.)
+        // to fail (this order differs from the double tap above).
         let singleTap = UITapGestureRecognizer(target: self, action: #selector(handleMapTap(sender:)))
         for recognizer in mapView.gestureRecognizers! where recognizer is UITapGestureRecognizer {
             singleTap.require(toFail: recognizer)
@@ -61,7 +61,8 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
         // Use a template image so that we can tint it with the `iconColor` runtime styling property.
         style.setImage(icon.withRenderingMode(.alwaysTemplate), forName: "icon")
 
-        // Show unclustered features as icons. The `cluster` attribute is built into clustering-enabled source features.
+        // Show unclustered features as icons. The `cluster` attribute is built into clustering-enabled
+        // source features.
         let ports = MGLSymbolStyleLayer(identifier: "ports", source: source)
         ports.iconImageName = NSExpression(forConstantValue: "icon")
         ports.iconColor = NSExpression(forConstantValue: UIColor.darkGray.withAlphaComponent(0.9))
@@ -76,7 +77,8 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
             200: UIColor.purple
         ]
 
-        // Show clustered features as circles. The `point_count` attribute is built into clustering-enabled source features.
+        // Show clustered features as circles. The `point_count` attribute is built into
+        // clustering-enabled source features.
         let circlesLayer = MGLCircleStyleLayer(identifier: "clusteredPorts", source: source)
         circlesLayer.circleRadius = NSExpression(forConstantValue: NSNumber(value: Double(icon.size.width) / 2))
         circlesLayer.circleOpacity = NSExpression(forConstantValue: 0.75)
@@ -86,7 +88,9 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
         circlesLayer.predicate = NSPredicate(format: "cluster == YES")
         style.addLayer(circlesLayer)
 
-        // Label cluster circles with a layer of text indicating feature count. The value for `point_count` is an integer. In order to use that value for the `MGLSymbolStyleLayer.text` property, cast it as a string. 
+        // Label cluster circles with a layer of text indicating feature count. The value for
+        // `point_count` is an integer. In order to use that value for the
+        // `MGLSymbolStyleLayer.text` property, cast it as a string.
         let numbersLayer = MGLSymbolStyleLayer(identifier: "clusteredPortsNumbers", source: source)
         numbersLayer.textColor = NSExpression(forConstantValue: UIColor.white)
         numbersLayer.textFontSize = NSExpression(forConstantValue: NSNumber(value: Double(icon.size.width) / 2))
@@ -107,13 +111,13 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
         let rect = CGRect(x: point.x - width / 2, y: point.y - width / 2, width: width, height: width)
 
         // This example shows how to check if a feature is a cluster by
-        // checking for that the feature is a `MGLPointFeatureCluster` (you could
-        // also check for conformance with `MGLCluster`)
+        // checking for that the feature is a `MGLPointFeatureCluster`. Alternatively, you could
+        // also check for conformance with `MGLCluster` instead.
         let features = mapView.visibleFeatures(in: rect, styleLayerIdentifiers: ["clusteredPorts", "ports"])
         let clusters = features.compactMap { $0 as? MGLPointFeatureCluster }
 
-        // Here we pick the first cluster, but ideally we'd pick the nearest one to
-        // the touch point
+        // Pick the first cluster, ideally selecting the one nearest nearest one to
+        // the touch point.
         return clusters.first
     }
 
@@ -158,8 +162,8 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
 
         let features = mapView.visibleFeatures(in: rect, styleLayerIdentifiers: ["clusteredPorts", "ports"])
 
-        // Pick the first feature (which could be a port or a cluster). Ideally this
-        // would pick the nearest feature to the touch point
+        // Pick the first feature (which may be a port or a cluster), ideally selecting
+        // the one nearest nearest one to the touch point.
         guard let feature = features.first else {
             return
         }
@@ -168,17 +172,17 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
         let color: UIColor
 
         if let cluster = feature as? MGLPointFeatureCluster {
-            // Tapped on a cluster
+            // Tapped on a cluster.
             let children = source.children(of: cluster)
             description = "Cluster #\(cluster.clusterIdentifier)\n\(children.count) children"
             color = .blue
         } else if let featureName = feature.attribute(forKey: "name") as? String?,
-            // Tapped on a port
+            // Tapped on a port.
             let portName = featureName {
             description = portName
             color = .black
         } else {
-            // Tapped on a port (missing a name)
+            // Tapped on a port that is missing a name.
             description = "No port name"
             color = .red
         }
@@ -188,7 +192,7 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
         showPopup(true, animated: true)
     }
 
-    // Convenience method to create a reusable popup view
+    // Convenience method to create a reusable popup view.
     private func popup(at coordinate: CLLocationCoordinate2D, with description: String, textColor: UIColor) -> UIView {
         let popup = UILabel()
 
@@ -205,7 +209,7 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
 
         popup.sizeToFit()
 
-        // Expand
+        // Expand the popup.
         popup.bounds = popup.bounds.insetBy(dx: -10, dy: -10)
         let point = mapView.convert(coordinate, toPointTo: mapView)
         popup.center = CGPoint(x: point.x, y: point.y - 50)

--- a/Examples/Swift/ClusteringExample.swift
+++ b/Examples/Swift/ClusteringExample.swift
@@ -83,7 +83,7 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
     }
 
     @objc @IBAction func handleMapTap(sender: UITapGestureRecognizer) throws {
-        
+
         guard let source = mapView.style?.source(withIdentifier: "clusteredPorts") as? MGLShapeSource else {
             return
         }
@@ -91,7 +91,7 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
         guard sender.state == .ended else {
             return
         }
-        
+
         showPopup(false, animated: false)
 
         let point = sender.location(in: sender.view)
@@ -117,15 +117,17 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
         let color: UIColor
 
         if let cluster = feature as? MGLCluster {
-
+            // Tapped on a cluster
             let children = source.children(of: cluster)
             description = "Cluster #\(cluster.clusterIdentifier)\n\(children.count) children\n\(cluster.clusterPointCountAbbreviation) points"
             color = .blue
         } else if let featureName = feature.attribute(forKey: "name") as? String?,
+            // Tapped on a port
             let portName = featureName {
             description = portName
             color = .black
         } else {
+            // Tapped on a port (missing a name)
             description = "No port name"
             color = .red
         }
@@ -165,20 +167,18 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
             return
         }
 
-        if (shouldShow) {
+        if shouldShow {
             view.addSubview(popup)
         }
 
         let alpha: CGFloat = (shouldShow ? 1 : 0)
 
         let animation = {
-            UIView.animate(withDuration: 0.25) {
-                popup.alpha = alpha
-            }
+            popup.alpha = alpha
         }
 
         let completion = { (_: Bool) in
-            if (!shouldShow) {
+            if !shouldShow {
                 popup.removeFromSuperview()
             }
         }


### PR DESCRIPTION
~~This PR is waiting for https://github.com/mapbox/mapbox-gl-native/pull/12952 to land in mapbox-gl-native~~

Updates cluster example to demostrate new cluster APIs.

Single tap on a cluster to see cluster information.
Double tap on a cluster to zoom into that cluster so that it expands to its children.