### PR TITLE
Rewrite comment explaining coordinate accuracy

### DIFF
--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.m
@@ -70,7 +70,7 @@
                    toDestination:(CLLocationCoordinate2D)destination
                       completion:(void(^)(MBRoute *_Nullable route, NSError *_Nullable error))completion {
     
-    // Coordinate accuracy is the maximum distance away from the waypoint that the route may still be considered viable, measured in meters. Negative values indicate that a indefinite number of meters away from the route and still be considered viable.
+    // Coordinate accuracy is how close the route must come to the waypoint in order to be considered viable. It is measured in meters. A negative value indicates that the route is viable regardless of how far the route is from the waypoint.
     MBWaypoint *originWaypoint = [[MBWaypoint alloc] initWithCoordinate:origin coordinateAccuracy:-1 name:@"Start"];
     
     MBWaypoint *destinationWaypoint = [[MBWaypoint alloc] initWithCoordinate:destination coordinateAccuracy:-1 name:@"Finish"];

--- a/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
+++ b/DocsCode/NavigationTutorial/NavigationTutorialViewController.swift
@@ -61,7 +61,7 @@ class ViewController: UIViewController, MGLMapViewDelegate {
                         to destination: CLLocationCoordinate2D,
                         completion: @escaping (Route?, Error?) -> ()) {
 
-        // Coordinate accuracy is the maximum distance away from the waypoint that the route may still be considered viable, measured in meters. Negative values indicate that a indefinite number of meters away from the route and still be considered viable.
+        // Coordinate accuracy is how close the route must come to the waypoint in order to be considered viable. It is measured in meters. A negative value indicates that the route is viable regardless of how far the route is from the waypoint.
         let origin = Waypoint(coordinate: origin, coordinateAccuracy: -1, name: "Start")
         let destination = Waypoint(coordinate: destination, coordinateAccuracy: -1, name: "Finish")
 


### PR DESCRIPTION
Rewrote comments associated with the lines that set `coordinateAccuracy`. These comments were based on [a MapboxDirections.swift documentation comment](https://github.com/mapbox/MapboxDirections.swift/blob/c350b60489c33845551cf0163a5481d32c940479/MapboxDirections/MBWaypoint.swift#L16) but somehow got mangled.

Fixes #265.

/cc @samfader