### PR TITLE
FeatureSelectionExample: Add fallback layer for older streets sources

### DIFF
--- a/Examples/ObjectiveC/FeatureSelectionExample.m
+++ b/Examples/ObjectiveC/FeatureSelectionExample.m
@@ -58,7 +58,8 @@ NSString const *MBXExampleFeatureSelection = @"FeatureSelectionExample";
     layer.fillColor = [NSExpression expressionWithFormat:@"mgl_interpolate:withCurveType:parameters:stops:(density, 'linear', nil, %@)", stops];
 
     // Insert the new layer below the Mapbox Streets layer that contains state border lines. See the layer reference for more information about layer names: https://www.mapbox.com/vector-tiles/mapbox-streets-v8/
-    MGLStyleLayer *symbolLayer = [style layerWithIdentifier:@"admin-1-boundary"];
+    // admin-1-boundary is available starting in mapbox-streets-v8, while admin-3-4-boundaries is provided here as a fallback for styles using older data sources.
+    MGLStyleLayer *symbolLayer = [style layerWithIdentifier:@"admin-1-boundary"] ?: [style layerWithIdentifier:@"admin-3-4-boundaries"];
     
     [style insertLayer:layer belowLayer:symbolLayer];
 }

--- a/Examples/Swift/FeatureSelectionExample.swift
+++ b/Examples/Swift/FeatureSelectionExample.swift
@@ -44,8 +44,12 @@ class FeatureSelectionExample_Swift: UIViewController, MGLMapViewDelegate {
         layer.fillColor = NSExpression(format: "mgl_interpolate:withCurveType:parameters:stops:(density, 'linear', nil, %@)", stops)
 
         // Insert the new layer below the Mapbox Streets layer that contains state border lines. See the layer reference for more information about layer names: https://www.mapbox.com/vector-tiles/mapbox-streets-v8/
-        let symbolLayer = style.layer(withIdentifier: "admin-1-boundary")
-        style.insertLayer(layer, below: symbolLayer!)
+        // admin-1-boundary is available starting in mapbox-streets-v8, while admin-3-4-boundaries is provided here as a fallback for styles using older data sources.
+        if let symbolLayer = style.layer(withIdentifier: "admin-1-boundary") ?? style.layer(withIdentifier: "admin-3-4-boundaries") {
+            style.insertLayer(layer, below: symbolLayer)
+        } else {
+            fatalError("Layer with specified identifier not found in current style")
+        }
     }
 
     @objc @IBAction func handleMapTap(sender: UITapGestureRecognizer) {


### PR DESCRIPTION
Fixes an issue introduced in [#249](https://github.com/mapbox/ios-sdk-examples/pull/249/commits/fd73525217773377393b9a883267ad366f278b5b) where a layer identifier was updated for streets-v8 without regard to backwards compatibility. Since 4.7.1 temporarily pulled v8 styles back as the defaults in the Maps SDK, this fixes a crash on every version except 4.7.0 and 4.8.0.

/cc @captainbarbosa @1ec5 @julianrex @fabian-guerra @zugaldia 

