### PR TITLE
Update for Maps SDK 4.11.0 (release-mojito)

### DIFF
--- a/Examples.xcodeproj/project.pbxproj
+++ b/Examples.xcodeproj/project.pbxproj
@@ -1772,6 +1772,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 0;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1794,6 +1795,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 0;
 				DEVELOPMENT_TEAM = GJZR2MEM28;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
 gem "cocoapods", ">= 1.6.0"
-gem "fastlane", "~> 2.105"
+gem "fastlane", "~> 2.121"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
     nap (1.1.0)
     naturally (2.2.0)
     netrc (0.11.0)
-    os (1.0.0)
+    os (1.0.1)
     plist (3.5.0)
     public_suffix (2.0.5)
     representable (3.0.4)
@@ -190,7 +190,7 @@ GEM
     unf_ext (0.0.7.6)
     unicode-display_width (1.5.0)
     word_wrap (1.0.0)
-    xcodeproj (1.8.2)
+    xcodeproj (1.9.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -206,7 +206,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (>= 1.6.0)
-  fastlane (~> 2.105)
+  fastlane (~> 2.121)
 
 BUNDLED WITH
    2.0.1

--- a/Podfile
+++ b/Podfile
@@ -7,7 +7,7 @@ def shared_pods
     if Dir.pwd.include?('mapbox-gl-native')
       pod 'Mapbox-iOS-SDK', :path => '../../../build/ios/pkg/dynamic/Mapbox-iOS-SDK.podspec'
     else
-      pod 'Mapbox-iOS-SDK', '4.10.0'
+      pod 'Mapbox-iOS-SDK', '4.11.0-alpha.1'
     end
 
     pod 'SwiftLint', '~> 0.29'

--- a/Podfile
+++ b/Podfile
@@ -7,7 +7,7 @@ def shared_pods
     if Dir.pwd.include?('mapbox-gl-native')
       pod 'Mapbox-iOS-SDK', :path => '../../../build/ios/pkg/dynamic/Mapbox-iOS-SDK.podspec'
     else
-      pod 'Mapbox-iOS-SDK', '4.11.0-alpha.1'
+      pod 'Mapbox-iOS-SDK', '4.11.0-alpha.2'
     end
 
     pod 'SwiftLint', '~> 0.29'

--- a/Podfile
+++ b/Podfile
@@ -7,7 +7,7 @@ def shared_pods
     if Dir.pwd.include?('mapbox-gl-native')
       pod 'Mapbox-iOS-SDK', :path => '../../../build/ios/pkg/dynamic/Mapbox-iOS-SDK.podspec'
     else
-      pod 'Mapbox-iOS-SDK', '4.11.0-alpha.2'
+      pod 'Mapbox-iOS-SDK', '4.11.0-beta.1'
     end
 
     pod 'SwiftLint', '~> 0.29'

--- a/Podfile
+++ b/Podfile
@@ -7,7 +7,7 @@ def shared_pods
     if Dir.pwd.include?('mapbox-gl-native')
       pod 'Mapbox-iOS-SDK', :path => '../../../build/ios/pkg/dynamic/Mapbox-iOS-SDK.podspec'
     else
-      pod 'Mapbox-iOS-SDK', '4.11.0-beta.1'
+      pod 'Mapbox-iOS-SDK', '4.11.0-beta.2'
     end
 
     pod 'SwiftLint', '~> 0.29'

--- a/Podfile
+++ b/Podfile
@@ -7,7 +7,7 @@ def shared_pods
     if Dir.pwd.include?('mapbox-gl-native')
       pod 'Mapbox-iOS-SDK', :path => '../../../build/ios/pkg/dynamic/Mapbox-iOS-SDK.podspec'
     else
-      pod 'Mapbox-iOS-SDK', '4.11.0-beta.2'
+      pod 'Mapbox-iOS-SDK', '4.11.0'
     end
 
     pod 'SwiftLint', '~> 0.29'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Mapbox-iOS-SDK (4.10.0)
+  - Mapbox-iOS-SDK (4.11.0)
   - MapboxCoreNavigation (0.33.0):
     - MapboxDirections.swift (~> 0.28.0)
     - MapboxMobileEvents (~> 0.9.3)
@@ -21,7 +21,7 @@ PODS:
   - Turf (0.3.0)
 
 DEPENDENCIES:
-  - Mapbox-iOS-SDK (= 4.10.0)
+  - Mapbox-iOS-SDK (= 4.11.0)
   - MapboxNavigation (= 0.33.0)
   - SwiftLint (~> 0.29)
 
@@ -40,7 +40,7 @@ SPEC REPOS:
     - Turf
 
 SPEC CHECKSUMS:
-  Mapbox-iOS-SDK: 8b1b777de7de373cdf000994c91af101ef886477
+  Mapbox-iOS-SDK: fa40ce2e941dcded1e49015c8bc98a654e8191a0
   MapboxCoreNavigation: b18785b61517628bcbc8d2d2c287812c71e8bdfe
   MapboxDirections.swift: bec8771badfbdd55a0194649a4194b2c2cb15b96
   MapboxMobileEvents: dea3b845b1a8528def7150dedf0cedefc6dfe284
@@ -52,6 +52,6 @@ SPEC CHECKSUMS:
   SwiftLint: 009a898ef2a1c851f45e1b59349bf6ff2ddc990d
   Turf: c6bdf62d6a70c647874f295dd1cf4eefc0c3e9e6
 
-PODFILE CHECKSUM: dcb833bac9f91e62b0a66731d08aa06f664270eb
+PODFILE CHECKSUM: dbbe7417359145ade7ddf927ca5f2677d7d07c56
 
 COCOAPODS: 1.6.1

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -6,7 +6,7 @@
 # Change the syntax highlighting to Ruby
 # All lines starting with a # are ignored when running `fastlane`
 
-fastlane_version "2.105.0"
+fastlane_version "2.121.0"
 opt_out_usage
 
 default_platform :ios
@@ -28,7 +28,7 @@ platform :ios do
     match(git_url: ENV["MATCH_REPO"], username: ENV["MATCH_USER"], type: "appstore", readonly: true)
     increment_build_number(build_number: latest_testflight_build_number + 1)
     gym(scheme: "Examples", include_bitcode: true)
-    pilot(changelog: release_notes, wait_for_uploaded_build: true)
+    pilot(changelog: release_notes)
   end
 
   desc "Generate release notes."


### PR DESCRIPTION
~Includes #278~, as we need that and it can’t be merged to `master` until we’re finished with that release.