### PR TITLE
Address ClusteringExample NSUInteger warnings

### DIFF
--- a/Examples/ObjectiveC/ClusteringExample.m
+++ b/Examples/ObjectiveC/ClusteringExample.m
@@ -196,7 +196,7 @@ NSString *const MBXExampleClustering = @"ClusteringExample";
         MGLPointFeatureCluster *cluster = (MGLPointFeatureCluster *)feature;
         
         NSArray *children = [(MGLShapeSource*)source childrenOfCluster:cluster];
-        description = [NSString stringWithFormat:@"Cluster #%ld\n%ld children",
+        description = [NSString stringWithFormat:@"Cluster #%zd\n%zd children",
                        cluster.clusterIdentifier,
                        children.count];
         color = UIColor.blueColor;


### PR DESCRIPTION
Fixes #276 

Used [`%zd`](https://useyourloaf.com/blog/format-string-issue-using-nsinteger/) to address the warnings.