### PR TITLE
Allow icon overlap for unclustered layer in ClusteringExample

### DIFF
--- a/Examples/ObjectiveC/ClusteringExample.m
+++ b/Examples/ObjectiveC/ClusteringExample.m
@@ -71,6 +71,7 @@ NSString *const MBXExampleClustering = @"ClusteringExample";
     // source features.
     MGLSymbolStyleLayer *ports = [[MGLSymbolStyleLayer alloc] initWithIdentifier:@"ports" source:source];
     ports.iconImageName = [NSExpression expressionForConstantValue:@"icon"];
+    ports.iconAllowsOverlap = [NSExpression expressionForConstantValue:@(YES)];
     ports.iconColor = [NSExpression expressionForConstantValue:[[UIColor darkGrayColor] colorWithAlphaComponent:0.9]];
     ports.predicate = [NSPredicate predicateWithFormat:@"cluster != YES"];
     [style addLayer:ports];

--- a/Examples/Swift/ClusteringExample.swift
+++ b/Examples/Swift/ClusteringExample.swift
@@ -67,6 +67,7 @@ class ClusteringExample_Swift: UIViewController, MGLMapViewDelegate {
         ports.iconImageName = NSExpression(forConstantValue: "icon")
         ports.iconColor = NSExpression(forConstantValue: UIColor.darkGray.withAlphaComponent(0.9))
         ports.predicate = NSPredicate(format: "cluster != YES")
+        ports.iconAllowsOverlap = NSExpression(forConstantValue: true)
         style.addLayer(ports)
 
         // Color clustered features based on clustered point counts.


### PR DESCRIPTION
Fixes #283 