### PR TITLE
Custom callout presentation should call delegate methods.

### DIFF
--- a/Examples/ObjectiveC/CustomCalloutView.m
+++ b/Examples/ObjectiveC/CustomCalloutView.m
@@ -56,6 +56,11 @@ static CGFloat const tipWidth = 20.0;
         return;
     }
 
+    if ([self.delegate respondsToSelector:@selector(calloutViewWillAppear:)])
+    {
+        [self.delegate calloutViewWillAppear:self];
+    }
+    
     [view addSubview:self];
 
     // Prepare title label.
@@ -81,13 +86,25 @@ static CGFloat const tipWidth = 20.0;
     self.frame = CGRectMake(frameOriginX, frameOriginY,
                             frameWidth, frameHeight);
 
+    dispatch_block_t didAppear = ^{
+        if ([self.delegate respondsToSelector:@selector(calloutViewDidAppear:)])
+        {
+            [self.delegate calloutViewDidAppear:self];
+        }
+    };
+    
     if (animated)
     {
         self.alpha = 0.0;
 
         [UIView animateWithDuration:0.2 animations:^{
             self.alpha = 1.0;
+            didAppear();
         }];
+    }
+    else
+    {
+        didAppear();
     }
 }
 

--- a/Examples/Swift/CustomCalloutView.swift
+++ b/Examples/Swift/CustomCalloutView.swift
@@ -50,8 +50,11 @@ class CustomCalloutView: UIView, MGLCalloutView {
     }
 
     // MARK: - MGLCalloutView API
-
+    
     func presentCallout(from rect: CGRect, in view: UIView, constrainedTo constrainedRect: CGRect, animated: Bool) {
+
+        delegate?.calloutViewWillAppear?(self)
+        
         view.addSubview(self)
 
         // Prepare title label.
@@ -77,8 +80,16 @@ class CustomCalloutView: UIView, MGLCalloutView {
             alpha = 0
 
             UIView.animate(withDuration: 0.2) { [weak self] in
-                self?.alpha = 1
+                guard let strongSelf = self else {
+                    return
+                }
+                
+                strongSelf.alpha = 1
+                strongSelf.delegate?.calloutViewDidAppear?(strongSelf)
             }
+        }
+        else {
+            delegate?.calloutViewDidAppear?(self)
         }
     }
 


### PR DESCRIPTION
Custom `MGLCalloutView` callouts should call `calloutViewWillAppear` / `calloutViewDidAppear` - without this, callout views can be out of synch (due to the toggling of `presentsWithTransaction:` introduced in https://github.com/mapbox/mapbox-gl-native/pull/14307).