### PR TITLE
Clean up Swiftlint warnings

### DIFF
--- a/Examples/Swift/CustomCalloutView.swift
+++ b/Examples/Swift/CustomCalloutView.swift
@@ -50,11 +50,10 @@ class CustomCalloutView: UIView, MGLCalloutView {
     }
 
     // MARK: - MGLCalloutView API
-    
     func presentCallout(from rect: CGRect, in view: UIView, constrainedTo constrainedRect: CGRect, animated: Bool) {
 
         delegate?.calloutViewWillAppear?(self)
-        
+
         view.addSubview(self)
 
         // Prepare title label.
@@ -83,12 +82,11 @@ class CustomCalloutView: UIView, MGLCalloutView {
                 guard let strongSelf = self else {
                     return
                 }
-                
+
                 strongSelf.alpha = 1
                 strongSelf.delegate?.calloutViewDidAppear?(strongSelf)
             }
-        }
-        else {
+        } else {
             delegate?.calloutViewDidAppear?(self)
         }
     }

--- a/Examples/Swift/LabelPlacementExample.swift
+++ b/Examples/Swift/LabelPlacementExample.swift
@@ -4,7 +4,7 @@ import Mapbox
 @objc(LabelPlacementExample_Swift)
 
 class LabelPlacementExample: UIViewController {
-    
+
     let mapView = MGLMapView()
 
     override func viewDidLoad() {
@@ -12,7 +12,7 @@ class LabelPlacementExample: UIViewController {
         // TODO: This is a test case, it should be changed to fulfill an ios example spec.
         mapView.frame = CGRect(x: 0, y: 0, width: view.bounds.width, height: view.bounds.height)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        
+
         // Set the map's initial style, center coordinate, and zoom level
         mapView.styleURL = MGLStyle.streetsStyleURL
         mapView.setCenter(CLLocationCoordinate2D(latitude: 37.791282, longitude: -122.396301), zoomLevel: 15.0, animated: false)

--- a/Examples/Swift/MissingIconsExample.swift
+++ b/Examples/Swift/MissingIconsExample.swift
@@ -4,7 +4,7 @@ import Mapbox
 @objc(MissingIconsExample_Swift)
 
 class MissingIconsExample: UIViewController {
-    
+
     let mapView = MGLMapView()
 
     override func viewDidLoad() {
@@ -15,22 +15,22 @@ class MissingIconsExample: UIViewController {
         mapView.centerCoordinate = CLLocationCoordinate2D(latitude: 0, longitude: 0)
         mapView.frame = CGRect(x: 0, y: 0, width: view.bounds.width, height: view.bounds.height)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        
+
         mapView.delegate = self
         view.addSubview(mapView)
-        
+
         // Create a button to load the faulty style.
-        let button = UIButton();
+        let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         button.layer.cornerRadius = 15
         button.backgroundColor = UIColor.white
         button.setTitle("Load faulty style", for: .normal)
         button.setTitleColor(UIColor.black, for: .normal)
         button.titleEdgeInsets = UIEdgeInsets(top: 5, left: 5, bottom: 5, right: 5)
-        button.titleLabel?.adjustsFontSizeToFitWidth = true;
+        button.titleLabel?.adjustsFontSizeToFitWidth = true
         button.addTarget(self, action: #selector(loadFaultyStyle(sender:)), for: .touchUpInside)
         view.addSubview(button)
-        
+
         if #available(iOS 11.0, *) {
             NSLayoutConstraint.activate([button.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
                                          button.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor, constant: 20)])
@@ -40,9 +40,8 @@ class MissingIconsExample: UIViewController {
 //                                         button.leftAnchor.constraint(equalTo: view.leftAnchor, constant: 20)])
         }
     }
-    
-    @objc
-    func loadFaultyStyle(sender: Any?) -> Void {
+
+    @objc func loadFaultyStyle(sender: Any?) {
         let customStyleJSON = Bundle.main.url(forResource: "missing_icon", withExtension: "json")
         mapView.styleURL = customStyleJSON
     }
@@ -50,14 +49,14 @@ class MissingIconsExample: UIViewController {
 }
 
 extension MissingIconsExample: MGLMapViewDelegate {
-    
+
     func mapView(_ mapView: MGLMapView, didFailToLoadImage imageName: String) -> UIImage? {
-        
+
         if (!(imageName == "skip-this-missing-icon")) {
             let backupImage = UIImage(named: "mapbox")
             return backupImage
         }
-        return nil;
+        return nil
     }
-    
+
 }

--- a/Examples/Swift/TextFormattingExample.swift
+++ b/Examples/Swift/TextFormattingExample.swift
@@ -4,7 +4,7 @@ import Mapbox
 @objc(TextFormattingExample_Swift)
 
 class TextFormattingExample_Swift: UIViewController {
-    
+
     let mapView = MGLMapView()
 
     override func viewDidLoad() {
@@ -12,11 +12,10 @@ class TextFormattingExample_Swift: UIViewController {
         // TODO: This is a test case, it should be changed to fulfill an ios example spec.
         mapView.frame = CGRect(x: 0, y: 0, width: view.bounds.width, height: view.bounds.height)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        
         mapView.styleURL = MGLStyle.streetsStyleURL
         mapView.setCenter(CLLocationCoordinate2D(latitude: 36.374782, longitude: -119.620859), zoomLevel: 6, animated: false)
         view.addSubview(mapView)
-        
+
         // Create a UISegmentedControl to toggle between map styles
         let styleToggle = UISegmentedControl(items: ["Expression", "JSON"])
         styleToggle.translatesAutoresizingMaskIntoConstraints = false
@@ -26,44 +25,44 @@ class TextFormattingExample_Swift: UIViewController {
         styleToggle.clipsToBounds = true
         view.insertSubview(styleToggle, aboveSubview: mapView)
         styleToggle.addTarget(self, action: #selector(formatText(sender:)), for: .valueChanged)
-        
+
         NSLayoutConstraint.activate([NSLayoutConstraint(item: styleToggle, attribute: NSLayoutAttribute.centerX, relatedBy: NSLayoutRelation.equal, toItem: mapView, attribute: NSLayoutAttribute.centerX, multiplier: 1.0, constant: 0.0)])
         NSLayoutConstraint.activate([NSLayoutConstraint(item: styleToggle, attribute: .bottom, relatedBy: .equal, toItem: mapView.logoView, attribute: .top, multiplier: 1, constant: -20)])
     }
-    
+
     // Format label's text based on the selected index of the UISegmentedControl
     @objc func formatText(sender: UISegmentedControl) {
         let stateLayer = mapView.style?.layer(withIdentifier: "state-label") as? MGLSymbolStyleLayer
-        var expression: NSExpression = NSExpression(forConstantValue:"")
-        
+        var expression: NSExpression = NSExpression(forConstantValue: "")
+
         switch sender.selectedSegmentIndex {
         case 0:
-            let firstRowAttribute = MGLAttributedExpression(expression: NSExpression(format:"name"))
-            let lineBreak = MGLAttributedExpression(expression: NSExpression(forConstantValue:"\n"))
-            let formatAttribute = MGLAttributedExpression(expression: NSExpression(format:"name"),
-                                                          attributes: [.fontScaleAttribute : NSExpression(forConstantValue:0.8),
-                                                                       .fontColorAttribute : NSExpression(forConstantValue:"blue"),
-                                                                       .fontNamesAttribute : NSExpression(forConstantValue:["Arial Unicode MS Bold"])])
+            let firstRowAttribute = MGLAttributedExpression(expression: NSExpression(format: "name"))
+            let lineBreak = MGLAttributedExpression(expression: NSExpression(forConstantValue: "\n"))
+            let formatAttribute = MGLAttributedExpression(expression: NSExpression(format: "name"),
+                                                          attributes: [.fontScaleAttribute: NSExpression(forConstantValue: 0.8),
+                                                                       .fontColorAttribute: NSExpression(forConstantValue: "blue"),
+                                                                       .fontNamesAttribute: NSExpression(forConstantValue: ["Arial Unicode MS Bold"])])
             let attributedExpression = NSExpression(format: "mgl_attributed:(%@, %@, %@)", NSExpression(forConstantValue: firstRowAttribute),
                                                                                             NSExpression(forConstantValue: lineBreak),
                                                                                             NSExpression(forConstantValue: formatAttribute))
-            
+
             expression = NSExpression(format: "MGL_MATCH(2 - 1,  1, %@, 'Foo')", attributedExpression)
-            
+
         case 1:
             let fileURL: URL = Bundle.main.url(forResource: "text-format", withExtension: "json")!
             let data = try? Data(contentsOf: fileURL)
             let jsonWithObjectRoot = try? JSONSerialization.jsonObject(with: data!, options: [])
-        
+
             if let jsonExpression = jsonWithObjectRoot as? [String: Any],
                 let jsonArray = jsonExpression["expression"] as? [Any] {
                 expression = NSExpression(mglJSONObject: jsonArray)
             }
-            
+
         default:
-            expression = NSExpression(forConstantValue:"default")
+            expression = NSExpression(forConstantValue: "default")
         }
-        
+
         stateLayer?.text = expression
     }
 

--- a/Examples/Swift/UserTrackingModesExample.swift
+++ b/Examples/Swift/UserTrackingModesExample.swift
@@ -53,7 +53,7 @@ class UserTrackingModesExample_Swift: UIViewController, MGLMapViewDelegate {
         // Setup constraints such that the button is placed within
         // the upper left corner of the view.
         button.translatesAutoresizingMaskIntoConstraints = false
-        var leadingConstraint : NSLayoutConstraint!
+        var leadingConstraint: NSLayoutConstraint!
         if #available(iOS 11.0, *) {
             let safeArea = view.safeAreaLayoutGuide
             leadingConstraint = NSLayoutConstraint(item: button, attribute: .leading, relatedBy: .equal, toItem: safeArea, attribute: .leading, multiplier: 1, constant: 10)


### PR DESCRIPTION
Fixes almost all of the Swiftlint warnings noted from https://github.com/mapbox/ios-sdk-examples/issues/302, with the exception of the `todo` warnings - these should be addressed by https://github.com/mapbox/ios-sdk-examples/issues/304 & #305.

cc @fabian-guerra 