### PR TITLE
Fix floating point precision warnings

### DIFF
--- a/Examples/ExamplesTableViewController.m
+++ b/Examples/ExamplesTableViewController.m
@@ -77,13 +77,13 @@ NSString *const MBXSegueTableToExample = @"TableToExampleSegue";
 #pragma mark - Table view data source
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
-    return [self.selectedGroup[@"categories"] count];
+    return [(NSArray *)self.selectedGroup[@"categories"] count];
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
     NSArray *examples = self.selectedGroup[@"categories"][section][@"examples"];
     
-    return  examples.count;
+    return examples.count;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {

--- a/Examples/ObjectiveC/AnnotationViewsAndImagesExample.m
+++ b/Examples/ObjectiveC/AnnotationViewsAndImagesExample.m
@@ -81,7 +81,7 @@ NSString *const MBXExampleAnnotationViewsAndImagesExample = @"AnnotationViewsAnd
         annotationView.layer.cornerRadius = annotationView.frame.size.width / 2;
         annotationView.layer.borderColor = [UIColor whiteColor].CGColor;
         annotationView.layer.borderWidth = 4.0;
-        annotationView.backgroundColor = [UIColor colorWithRed:0.03 green:0.80 blue:0.69 alpha:1.0];
+        annotationView.backgroundColor = [UIColor colorWithRed:0.03f green:0.80f blue:0.69f alpha:1];
     }
     
     return annotationView;

--- a/Examples/ObjectiveC/BuildingLightExample.m
+++ b/Examples/ObjectiveC/BuildingLightExample.m
@@ -32,7 +32,7 @@ NSString *const MBXExampleBuildingLight = @"BuildingLightExample";
 
 // Add a slider to the map view. This will be used to adjust the map's light object.
 - (void)addSlider {
-    self.slider = [[UISlider alloc] initWithFrame:CGRectMake(self.view.frame.size.width / 8, self.view.frame.size.height - 60, self.view.frame.size.width * 0.75, 20)];
+    self.slider = [[UISlider alloc] initWithFrame:CGRectMake(self.view.frame.size.width / 8, self.view.frame.size.height - 60, self.view.frame.size.width * 0.75f, 20)];
     self.slider.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
     self.slider.minimumValue = -180;
     self.slider.maximumValue = 180;

--- a/Examples/ObjectiveC/ClusteringExample.m
+++ b/Examples/ObjectiveC/ClusteringExample.m
@@ -72,7 +72,7 @@ NSString *const MBXExampleClustering = @"ClusteringExample";
     MGLSymbolStyleLayer *ports = [[MGLSymbolStyleLayer alloc] initWithIdentifier:@"ports" source:source];
     ports.iconImageName = [NSExpression expressionForConstantValue:@"icon"];
     ports.iconAllowsOverlap = [NSExpression expressionForConstantValue:@(YES)];
-    ports.iconColor = [NSExpression expressionForConstantValue:[[UIColor darkGrayColor] colorWithAlphaComponent:0.9]];
+    ports.iconColor = [NSExpression expressionForConstantValue:[[UIColor darkGrayColor] colorWithAlphaComponent:0.9f]];
     ports.predicate = [NSPredicate predicateWithFormat:@"cluster != YES"];
     [style addLayer:ports];
 
@@ -220,7 +220,7 @@ NSString *const MBXExampleClustering = @"ClusteringExample";
 - (UIView *)popupAtCoordinate:(CLLocationCoordinate2D)coordinate withDescription:(NSString *)description textColor:(UIColor *)textColor {
     UILabel *popup = [[UILabel alloc] init];
     
-    popup.backgroundColor     = [[UIColor whiteColor] colorWithAlphaComponent:0.9];
+    popup.backgroundColor     = [[UIColor whiteColor] colorWithAlphaComponent:0.9f];
     popup.layer.cornerRadius  = 4;
     popup.layer.masksToBounds = YES;
     popup.textAlignment       = NSTextAlignmentCenter;

--- a/Examples/ObjectiveC/CustomCalloutView.m
+++ b/Examples/ObjectiveC/CustomCalloutView.m
@@ -81,7 +81,7 @@ static CGFloat const tipWidth = 20.0;
     // Prepare our frame, adding extra space at the bottom for the tip.
     CGFloat frameWidth = self.mainBody.bounds.size.width;
     CGFloat frameHeight = self.mainBody.bounds.size.height + tipHeight;
-    CGFloat frameOriginX = rect.origin.x + (rect.size.width/2.0) - (frameWidth/2.0);
+    CGFloat frameOriginX = rect.origin.x + (rect.size.width/2.0f) - (frameWidth/2.0f);
     CGFloat frameOriginY = rect.origin.y - frameHeight;
     self.frame = CGRectMake(frameOriginX, frameOriginY,
                             frameWidth, frameHeight);
@@ -173,8 +173,8 @@ static CGFloat const tipWidth = 20.0;
     // Draw the pointed tip at the bottom
     UIColor *fillColor = [self backgroundColorForCallout];
 
-    CGFloat tipLeft = rect.origin.x + (rect.size.width / 2.0) - (tipWidth / 2.0);
-    CGPoint tipBottom = CGPointMake(rect.origin.x + (rect.size.width / 2.0), rect.origin.y + rect.size.height);
+    CGFloat tipLeft = rect.origin.x + (rect.size.width / 2.0f) - (tipWidth / 2.0f);
+    CGPoint tipBottom = CGPointMake(rect.origin.x + (rect.size.width / 2.0f), rect.origin.y + rect.size.height);
     CGFloat heightWithoutTip = rect.size.height - tipHeight - 1;
 
     CGContextRef currentContext = UIGraphicsGetCurrentContext();

--- a/Examples/ObjectiveC/DDSCircleLayerExample.m
+++ b/Examples/ObjectiveC/DDSCircleLayerExample.m
@@ -45,15 +45,15 @@ NSString *const MBXExampleDDSCircleLayer = @"DDSCircleLayerExample";
     
     // Stops based on age of tree in years.
     NSDictionary *stops = @{
-        @0: [UIColor colorWithRed:1.00 green:0.72 blue:0.85 alpha:1.0],
-        @2: [UIColor colorWithRed:0.69 green:0.48 blue:0.73 alpha:1.0],
-        @4: [UIColor colorWithRed:0.61 green:0.31 blue:0.47 alpha:1.0],
-        @7: [UIColor colorWithRed:0.43 green:0.20 blue:0.38 alpha:1.0],
-        @16: [UIColor colorWithRed:0.33 green:0.17 blue:0.25 alpha:1.0]
+        @0: [UIColor colorWithRed:1.00f green:0.72f blue:0.85f alpha:1.0f],
+        @2: [UIColor colorWithRed:0.69f green:0.48f blue:0.73f alpha:1.0f],
+        @4: [UIColor colorWithRed:0.61f green:0.31f blue:0.47f alpha:1.0f],
+        @7: [UIColor colorWithRed:0.43f green:0.20f blue:0.38f alpha:1.0f],
+        @16: [UIColor colorWithRed:0.33f green:0.17f blue:0.25f alpha:1.0f]
     };
     
     // Style the circle layer color based on the above stops dictionary.
-    layer.circleColor = [NSExpression expressionWithFormat:@"mgl_step:from:stops:(AGE, %@, %@)", [UIColor colorWithRed:1.0 green:0.72 blue:0.85 alpha:1.0], stops];
+    layer.circleColor = [NSExpression expressionWithFormat:@"mgl_step:from:stops:(AGE, %@, %@)", [UIColor colorWithRed:1.0f green:0.72f blue:0.85f alpha:1], stops];
  
     layer.circleRadius = [NSExpression expressionForConstantValue:@3];
     

--- a/Examples/ObjectiveC/HeatmapExample.m
+++ b/Examples/ObjectiveC/HeatmapExample.m
@@ -34,8 +34,8 @@ NSString *const MBXExampleHeatmap = @"HeatmapExample";
     // Adjust the color of the heatmap based on the point density.
     NSDictionary *colorDictionary = @{ @0 : [UIColor clearColor],
                                        @0.01 : [UIColor whiteColor],
-                                       @0.1 : [UIColor colorWithRed:0.19 green:0.3 blue:0.8 alpha:1.0],
-                                       @0.5 : [UIColor colorWithRed:0.73 green:0.23 blue:0.25 alpha:1.0],
+                                       @0.1 : [UIColor colorWithRed:0.19f green:0.3f blue:0.8f alpha:1],
+                                       @0.5 : [UIColor colorWithRed:0.73f green:0.23f blue:0.25f alpha:1],
                                        @1 : [UIColor yellowColor]
                                        };
     heatmapLayer.heatmapColor = [NSExpression expressionWithFormat:@"mgl_interpolate:withCurveType:parameters:stops:($heatmapDensity, 'linear', nil, %@)", colorDictionary];
@@ -56,8 +56,8 @@ NSString *const MBXExampleHeatmap = @"HeatmapExample";
     
     NSDictionary *magnitudeDictionary = @{@0 : [UIColor whiteColor],
                                           @0.5 : [UIColor yellowColor],
-                                          @2.5 : [UIColor colorWithRed:0.73 green:0.23 blue:0.25 alpha:1.0],
-                                          @5 : [UIColor colorWithRed:0.19 green:0.30 blue:0.80 alpha:1.0]
+                                          @2.5 : [UIColor colorWithRed:0.73f green:0.23f blue:0.25f alpha:1],
+                                          @5 : [UIColor colorWithRed:0.19f green:0.30f blue:0.80f alpha:1]
                                           };
     circleLayer.circleColor = [NSExpression expressionWithFormat:@"mgl_interpolate:withCurveType:parameters:stops:(mag, 'linear', nil, %@)", magnitudeDictionary];
     

--- a/Examples/ObjectiveC/LineStyleLayerExample.m
+++ b/Examples/ObjectiveC/LineStyleLayerExample.m
@@ -54,7 +54,7 @@ NSString *const MBXExampleLineStyleLayer = @"LineStyleLayerExample";
     layer.lineCap = [NSExpression expressionForConstantValue:[NSValue valueWithMGLLineCap:MGLLineCapRound]];
     
     // Set the line color to a constant blue color.
-    layer.lineColor = [NSExpression expressionForConstantValue:[UIColor colorWithRed:59/255.0 green:178/255.0 blue:208/255.0 alpha:1]];
+    layer.lineColor = [NSExpression expressionForConstantValue:[UIColor colorWithRed:59/255.0f green:178/255.0f blue:208/255.0f alpha:1]];
     
     // Use `NSExpression` to smoothly adjust the line width from 2pt to 20pt between zoom levels 14 and 18. The `interpolationBase` parameter allows the values to interpolate along an exponential curve
     layer.lineWidth = [NSExpression expressionWithFormat:@"mgl_interpolate:withCurveType:parameters:stops:($zoomLevel, 'linear', nil, %@)",
@@ -68,7 +68,7 @@ NSString *const MBXExampleLineStyleLayer = @"LineStyleLayerExample";
     // Line gap width represents the space before the outline begins, so should match the main line’s line width exactly.
     casingLayer.lineGapWidth = layer.lineWidth;
     // Stroke color slightly darker than the line color.
-    casingLayer.lineColor = [NSExpression expressionForConstantValue:[UIColor colorWithRed:41/255.0 green:145/255.0 blue:171/255.0 alpha:1]];
+    casingLayer.lineColor = [NSExpression expressionForConstantValue:[UIColor colorWithRed:41/255.0f green:145/255.0f blue:171/255.0f alpha:1]];
     // Use a style function to gradually increase the stroke width between zoom levels 14 and 18.
     casingLayer.lineWidth = [NSExpression expressionWithFormat:@"mgl_interpolate:withCurveType:parameters:stops:($zoomLevel, 'linear', nil, %@)",
                              @{@14: @1, @18: @4}];

--- a/Examples/ObjectiveC/OfflinePackExample.m
+++ b/Examples/ObjectiveC/OfflinePackExample.m
@@ -80,7 +80,7 @@ NSString *const MBXExampleOfflinePack = @"OfflinePackExample";
     if (!self.progressView) {
         self.progressView = [[UIProgressView alloc] initWithProgressViewStyle:UIProgressViewStyleDefault];
         CGSize frame = self.view.bounds.size;
-        self.progressView.frame = CGRectMake(frame.width / 4, frame.height * 0.75, frame.width / 2, 10);
+        self.progressView.frame = CGRectMake(frame.width / 4, frame.height * 0.75f, frame.width / 2, 10);
         [self.view addSubview:self.progressView];
     }
 

--- a/Examples/ObjectiveC/StaticSnapshotExample.m
+++ b/Examples/ObjectiveC/StaticSnapshotExample.m
@@ -27,7 +27,7 @@ NSString *const MBXExampleStaticSnapshot = @"StaticSnapshotExample";
     // Create a button to take a map snapshot.
     _button = [[UIButton alloc] initWithFrame:CGRectMake(_mapView.bounds.size.width / 2 - 15, _mapView.bounds.size.height - 40, 80, 30)];
     _button.layer.cornerRadius = 15;
-    _button.backgroundColor = [UIColor colorWithRed:0.96 green:0.65 blue:0.14 alpha:1.0];
+    _button.backgroundColor = [UIColor colorWithRed:0.96f green:0.65f blue:0.14f alpha:1];
     [_button setImage:[UIImage imageNamed:@"camera"] forState:UIControlStateNormal];
     [_button addTarget:self action:@selector(createSnapshot) forControlEvents:UIControlEventTouchUpInside];
     [self.view addSubview:_button];

--- a/Examples/ObjectiveC/SwitchStylesExample.m
+++ b/Examples/ObjectiveC/SwitchStylesExample.m
@@ -27,8 +27,8 @@ NSString *const MBXExampleSwitchStyles = @"SwitchStylesExample";
     // Create a UISegmentedControl to toggle between map styles
     UISegmentedControl *styleToggle =[[UISegmentedControl alloc] initWithItems:@[@"Satellite", @"Streets", @"Light"]];
     styleToggle.translatesAutoresizingMaskIntoConstraints = NO;
-    styleToggle.tintColor = [UIColor colorWithRed:0.976 green:0.843 blue:0.831 alpha:1];
-    styleToggle.backgroundColor = [UIColor colorWithRed:0.973 green:0.329 blue:0.294 alpha:1];
+    styleToggle.tintColor = [UIColor colorWithRed:0.976f green:0.843f blue:0.831f alpha:1];
+    styleToggle.backgroundColor = [UIColor colorWithRed:0.973f green:0.329f blue:0.294f alpha:1];
     styleToggle.layer.cornerRadius = 4;
     styleToggle.clipsToBounds = YES;
     styleToggle.selectedSegmentIndex = 1;

--- a/Examples/ObjectiveC/TextFormattingExample.m
+++ b/Examples/ObjectiveC/TextFormattingExample.m
@@ -25,8 +25,8 @@ NSString *const MBXExampleFormattingExpression = @"TextFormattingExample";
     
     UISegmentedControl *styleToggle =[[UISegmentedControl alloc] initWithItems:@[@"Expression", @"JSON"]];
     styleToggle.translatesAutoresizingMaskIntoConstraints = NO;
-    styleToggle.tintColor = [UIColor colorWithRed:0.976 green:0.843 blue:0.831 alpha:1];
-    styleToggle.backgroundColor = [UIColor colorWithRed:0.973 green:0.329 blue:0.294 alpha:1];
+    styleToggle.tintColor = [UIColor colorWithRed:0.976f green:0.843f blue:0.831f alpha:1];
+    styleToggle.backgroundColor = [UIColor colorWithRed:0.973f green:0.329f blue:0.294f alpha:1];
     styleToggle.layer.cornerRadius = 4;
     styleToggle.clipsToBounds = YES;
     [self.view insertSubview:styleToggle aboveSubview:self.mapView];

--- a/Examples/ObjectiveC/UserLocationAnnotationExample.m
+++ b/Examples/ObjectiveC/UserLocationAnnotationExample.m
@@ -83,10 +83,10 @@ NSString *const MBXExampleUserLocationAnnotation = @"UserLocationAnnotationExamp
     CGFloat max = _size / 2;
     CGFloat pad = 3;
     
-    CGPoint top =    CGPointMake(max * 0.5, 0);
-    CGPoint left =   CGPointMake(0 + pad,   max - pad);
-    CGPoint right =  CGPointMake(max - pad, max - pad);
-    CGPoint center = CGPointMake(max * 0.5, max * 0.6);
+    CGPoint top =    CGPointMake(max * 0.5f, 0);
+    CGPoint left =   CGPointMake(0 + pad,    max - pad);
+    CGPoint right =  CGPointMake(max - pad,  max - pad);
+    CGPoint center = CGPointMake(max * 0.5f, max * 0.6f);
     
     UIBezierPath *bezierPath = [UIBezierPath bezierPath];
     [bezierPath moveToPoint:top];

--- a/Examples/ObjectiveC/UserTrackingModesExample.m
+++ b/Examples/ObjectiveC/UserTrackingModesExample.m
@@ -19,7 +19,7 @@ NSString *const MBXExampleUserTrackingModes = @"UserTrackingModesExample";
 - (instancetype)initWithButtonSize:(CGFloat)buttonSize {
     if (self = [super init]) {
         self.frame = CGRectMake(0, 0, buttonSize, buttonSize);
-        self.backgroundColor = [[UIColor whiteColor] colorWithAlphaComponent:0.9];
+        self.backgroundColor = [[UIColor whiteColor] colorWithAlphaComponent:0.9f];
         self.layer.cornerRadius = 4;
         self.buttonSize = buttonSize;
         
@@ -50,11 +50,11 @@ NSString *const MBXExampleUserTrackingModes = @"UserTrackingModesExample";
 - (CGPathRef)arrowPath {
     UIBezierPath *bezierPath = [[UIBezierPath alloc] init];
     CGFloat max = self.buttonSize / 2;
-    [bezierPath moveToPoint:CGPointMake(max * 0.5, 0)];
-    [bezierPath addLineToPoint:CGPointMake(max * 0.1, max)];
-    [bezierPath addLineToPoint:CGPointMake(max * 0.5, max * 0.65)];
-    [bezierPath addLineToPoint:CGPointMake(max * 0.9, max)];
-    [bezierPath addLineToPoint:CGPointMake(max * 0.5, 0)];
+    [bezierPath moveToPoint:CGPointMake(max * 0.5f,    0)];
+    [bezierPath addLineToPoint:CGPointMake(max * 0.1f, max)];
+    [bezierPath addLineToPoint:CGPointMake(max * 0.5f, max * 0.65f)];
+    [bezierPath addLineToPoint:CGPointMake(max * 0.9f, max)];
+    [bezierPath addLineToPoint:CGPointMake(max * 0.5f, 0)];
     [bezierPath closePath];
     
     return bezierPath.CGPath;
@@ -65,7 +65,7 @@ NSString *const MBXExampleUserTrackingModes = @"UserTrackingModesExample";
     UIColor *activePrimaryColor = UIColor.redColor;
     UIColor *disabledPrimaryColor = UIColor.clearColor;
     UIColor *disabledSecondaryColor = UIColor.blackColor;
-    CGFloat rotatedArrow = 0.66;
+    CGFloat rotatedArrow = 0.66f;
     
     switch (mode) {
         case MGLUserTrackingModeNone:

--- a/Examples/ObjectiveC/WebAPIDataExample.m
+++ b/Examples/ObjectiveC/WebAPIDataExample.m
@@ -46,7 +46,7 @@ NSString *const MBXExampleWebAPIData = @"WebAPIDataExample";
     MGLShapeSource *source = [[MGLShapeSource alloc] initWithIdentifier:@"lighthouses" features:features options:nil];
     [self.mapView.style addSource:source];
 
-    UIColor *lighthouseColor = [UIColor colorWithRed:0.08 green:0.44 blue:0.96 alpha:1.0];
+    UIColor *lighthouseColor = [UIColor colorWithRed:0.08f green:0.44f blue:0.96f alpha:1];
 
     // Use MGLCircleStyleLayer to represent the points with simple circles.
     // In this case, we can use style functions to gradually change properties between zoom level 2 and 7: the circle opacity from 50% to 100% and the circle radius from 2pt to 3pt.


### PR DESCRIPTION
Fixes a variety of `implicit conversion loses floating-point precision: 'double' to 'CGFloat' (aka 'float') [-Wimplicit-float-conversion]` warnings when building for release.

/cc @captainbarbosa 