### PR TITLE
OfflinePackExample: limit impact of offline pack downloads on the app

### DIFF
--- a/Examples/ObjectiveC/OfflinePackExample.m
+++ b/Examples/ObjectiveC/OfflinePackExample.m
@@ -34,8 +34,20 @@ NSString *const MBXExampleOfflinePack = @"OfflinePackExample";
     [self startOfflinePackDownload];
 }
 
+- (void)viewDidDisappear:(BOOL)animated {
+    [super viewDidDisappear:animated];
+
+    // When leaving this view controller, suspend offline downloads.
+    for (MGLOfflinePack *pack in MGLOfflineStorage.sharedOfflineStorage.packs) {
+        NSDictionary *userInfo = [NSKeyedUnarchiver unarchiveObjectWithData:pack.context];
+        NSLog(@"Suspending download of offline pack: %@", userInfo[@"name"]);
+        [pack suspend];
+    }
+}
+
 - (void)dealloc {
     // Remove offline pack observers.
+    NSLog(@"Removing offline pack notification observers");
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 

--- a/Examples/ObjectiveC/OfflinePackExample.m
+++ b/Examples/ObjectiveC/OfflinePackExample.m
@@ -30,7 +30,7 @@ NSString *const MBXExampleOfflinePack = @"OfflinePackExample";
 }
 
 - (void)mapViewDidFinishLoadingMap:(MGLMapView *)mapView {
-    // Start downloading tiles and resources for z13-16.
+    // Start downloading tiles and resources for z13-14.
     [self startOfflinePackDownload];
 }
 
@@ -54,7 +54,7 @@ NSString *const MBXExampleOfflinePack = @"OfflinePackExample";
 - (void)startOfflinePackDownload {
     // Create a region that includes the current viewport and any tiles needed to view it when zoomed further in.
     // Because tile count grows exponentially with the maximum zoom level, you should be conservative with your `toZoomLevel` setting.
-    id <MGLOfflineRegion> region = [[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:self.mapView.styleURL bounds:self.mapView.visibleCoordinateBounds fromZoomLevel:self.mapView.zoomLevel toZoomLevel:16];
+    id <MGLOfflineRegion> region = [[MGLTilePyramidOfflineRegion alloc] initWithStyleURL:self.mapView.styleURL bounds:self.mapView.visibleCoordinateBounds fromZoomLevel:self.mapView.zoomLevel toZoomLevel:14];
 
     // Store some data for identification purposes alongside the downloaded resources.
     NSDictionary *userInfo = @{ @"name": @"My Offline Pack" };

--- a/Examples/Swift/OfflinePackExample.swift
+++ b/Examples/Swift/OfflinePackExample.swift
@@ -29,8 +29,22 @@ class OfflinePackExample_Swift: UIViewController, MGLMapViewDelegate {
         startOfflinePackDownload()
     }
 
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+
+        // When leaving this view controller, suspend offline downloads.
+        guard let packs = MGLOfflineStorage.shared.packs else { return }
+        for pack in packs {
+            if let userInfo = NSKeyedUnarchiver.unarchiveObject(with: pack.context) as? [String: String] {
+                print("Suspending download of offline pack: “\(userInfo["name"] ?? "unknown")”")
+            }
+            pack.suspend()
+        }
+    }
+
     deinit {
         // Remove offline pack observers.
+        print("Removing offline pack notification observers")
         NotificationCenter.default.removeObserver(self)
     }
 
@@ -89,7 +103,7 @@ class OfflinePackExample_Swift: UIViewController, MGLMapViewDelegate {
                 print("Offline pack “\(userInfo["name"] ?? "unknown")” completed: \(byteCount), \(completedResources) resources")
             } else {
                 // Otherwise, print download/verification progress.
-                print("Offline pack “\(userInfo["name"] ?? "unknown")” has \(completedResources) of \(expectedResources) resources — \(progressPercentage * 100)%.")
+                print("Offline pack “\(userInfo["name"] ?? "unknown")” has \(completedResources) of \(expectedResources) resources — \(String(format: "%.2f", progressPercentage * 100))%.")
             }
         }
     }

--- a/Examples/Swift/OfflinePackExample.swift
+++ b/Examples/Swift/OfflinePackExample.swift
@@ -25,7 +25,7 @@ class OfflinePackExample_Swift: UIViewController, MGLMapViewDelegate {
     }
 
     func mapViewDidFinishLoadingMap(_ mapView: MGLMapView) {
-        // Start downloading tiles and resources for z13-16.
+        // Start downloading tiles and resources for z13-14.
         startOfflinePackDownload()
     }
 
@@ -51,7 +51,7 @@ class OfflinePackExample_Swift: UIViewController, MGLMapViewDelegate {
     func startOfflinePackDownload() {
         // Create a region that includes the current viewport and any tiles needed to view it when zoomed further in.
         // Because tile count grows exponentially with the maximum zoom level, you should be conservative with your `toZoomLevel` setting.
-        let region = MGLTilePyramidOfflineRegion(styleURL: mapView.styleURL, bounds: mapView.visibleCoordinateBounds, fromZoomLevel: mapView.zoomLevel, toZoomLevel: 16)
+        let region = MGLTilePyramidOfflineRegion(styleURL: mapView.styleURL, bounds: mapView.visibleCoordinateBounds, fromZoomLevel: mapView.zoomLevel, toZoomLevel: 14)
 
         // Store some data for identification purposes alongside the downloaded resources.
         let userInfo = ["name": "My Offline Pack"]


### PR DESCRIPTION
Fixes #340. Should let UI tests be marginally better performant/more reliable, since offline pack downloads won’t spill over outside the relevant view controller.

/cc @captainbarbosa @jmkiley 