### PR TITLE
Modernize table view appearance

### DIFF
--- a/Examples/Examples.m
+++ b/Examples/Examples.m
@@ -143,7 +143,7 @@
     
     return @[
         @{@"title": @"Swift", @"categories": swiftCategories},
-        @{@"title": @"ObjC", @"categories": objcCategories}
+        @{@"title": @"Objective-C", @"categories": objcCategories}
     ];
 }
 

--- a/Examples/ExamplesTableViewController.m
+++ b/Examples/ExamplesTableViewController.m
@@ -65,8 +65,10 @@ NSString *const MBXSegueTableToExample = @"TableToExampleSegue";
     self.languagesSegementControl = languagesSegementControl;
 }
 
--(void)viewWillAppear:(BOOL)animated {
-    [super viewWillAppear:animated];
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+    [super traitCollectionDidChange:previousTraitCollection];
+
+    [self.languagesSegementControl sizeToFit];
 }
 
 #pragma mark - Segement control event handle
@@ -104,19 +106,19 @@ NSString *const MBXSegueTableToExample = @"TableToExampleSegue";
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
 {
-    return 40;
+    return 60;
 }
 
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
 {
     UIView *headerView = [[UIView alloc] init];
-    headerView.backgroundColor = tableView.separatorColor;
-    headerView.bounds = CGRectMake(0, 0, tableView.bounds.size.width, 40);
+    headerView.bounds = CGRectMake(0, 0, tableView.bounds.size.width, 60);
     
     UILabel *label = [[UILabel alloc] init];
     label.frame = UIEdgeInsetsInsetRect(headerView.bounds, UIEdgeInsetsMake(0, tableView.separatorInset.left, 0, 0));
     label.text = self.selectedGroup[@"categories"][section][@"title"];
-    
+    label.font = [UIFont preferredFontForTextStyle:UIFontTextStyleTitle1];
+
     [headerView addSubview:label];
 
     return headerView;

--- a/Examples/Main.storyboard
+++ b/Examples/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="zVY-QI-Wcr">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="zVY-QI-Wcr">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -13,30 +11,30 @@
         <scene sceneID="Z8w-ct-53h">
             <objects>
                 <tableViewController title="Mapbox Examples Table" id="rYw-fr-DVv" customClass="ExamplesTableViewController" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="jqC-bf-Q1D">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="jqC-bf-Q1D">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="ExampleCell" textLabel="2OV-ag-M78" detailTextLabel="4MT-rt-T23" style="IBUITableViewCellStyleSubtitle" id="uOq-7b-YXm">
-                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="ExampleCell" textLabel="2OV-ag-M78" detailTextLabel="4MT-rt-T23" style="IBUITableViewCellStyleSubtitle" id="uOq-7b-YXm">
+                                <rect key="frame" x="16" y="55.5" width="343" height="52.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="uOq-7b-YXm" id="Y0e-IA-9M7">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="343" height="52.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="2OV-ag-M78">
-                                            <rect key="frame" x="16" y="5" width="33.5" height="20.5"/>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" id="2OV-ag-M78">
+                                            <rect key="frame" x="15" y="7.5" width="30" height="18"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                            <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="4MT-rt-T23">
-                                            <rect key="frame" x="16" y="25.5" width="44" height="14.5"/>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" id="4MT-rt-T23">
+                                            <rect key="frame" x="15" y="28" width="44" height="14.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                            <nil key="textColor"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                            <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
@@ -92,7 +90,7 @@
             <objects>
                 <navigationController id="icM-J6-7Ve" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="62O-Wd-YC9">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>

--- a/ExamplesUITests/ExamplesUITests.m
+++ b/ExamplesUITests/ExamplesUITests.m
@@ -41,7 +41,7 @@
 - (void)testAnimatedLineExampleObjC {
     
     [XCTContext runActivityNamed:@"AnimatedLineExample" block:^(id<XCTActivity>  _Nonnull activity) {
-        [self.app.navigationBars[@"Examples"].buttons[@"ObjC"] tap];
+        [self.app.navigationBars[@"Examples"].buttons[@"Objective-C"] tap];
         [self.app.tables.staticTexts[@"Animate a line"] tap];
 
         // Wait for notification
@@ -62,7 +62,7 @@
     __block XCUIElement *compass;
 
     [XCTContext runActivityNamed:@"Wait for initial render" block:^(id<XCTActivity>  _Nonnull activity) {
-        [self.app.navigationBars[@"Examples"].buttons[@"ObjC"] tap];
+        [self.app.navigationBars[@"Examples"].buttons[@"Objective-C"] tap];
         [self.app.tables.staticTexts[@"Annotation views"] tap];
         XCUIElementQuery *allQuery = [self.app descendantsMatchingType:XCUIElementTypeAny];
         element = [allQuery elementMatchingType:XCUIElementTypeAny identifier:@"MGLMapViewId"];
@@ -98,7 +98,7 @@
     __block XCUIElement *slider;
 
     [XCTContext runActivityNamed:@"Wait for initial render" block:^(id<XCTActivity>  _Nonnull activity) {
-        [self.app.navigationBars[@"Examples"].buttons[@"ObjC"] tap];
+        [self.app.navigationBars[@"Examples"].buttons[@"Objective-C"] tap];
         [self.app.tables.staticTexts[@"Adjust lighting of 3D buildings"] tap];
         XCUIElementQuery *allQuery = [self.app descendantsMatchingType:XCUIElementTypeAny];
         element = [allQuery elementMatchingType:XCUIElementTypeAny identifier:@"MGLMapViewId"];
@@ -119,7 +119,7 @@
 
 
 - (void)testEveryExample {
-    [self runTestsForEveryExampleWithLanguage:@"ObjC"];
+    [self runTestsForEveryExampleWithLanguage:@"Objective-C"];
     [self runTestsForEveryExampleWithLanguage:@"Swift"];
 }
 


### PR DESCRIPTION
Some really quick changes to the table view’s appearance while we consider what the next version of this app will be.

- Adopts the modern `UITableViewStyleInsetGrouped` appearance, which is new in iOS 13 but is generally backwards compatible.
- Fixes #338 by adding support for dark mode, mainly by using semantic colors.
- Adds basic support for dynamic type and multiline wrapping of long strings.

### To-do
- [x] ~Fix warnings in Interface Builder about unavailable self-sizing properties.~ Going to let these go, since this functionality will likely change soon and the warnings appear harmless.

### Screenshots

| ![Simulator Screen Shot - iPhone X - 2019-09-07 at 00 00 58](https://user-images.githubusercontent.com/1198851/64471182-d5e1de00-d102-11e9-8e84-55142c81fca0.png) | ![Simulator Screen Shot - iPhone X - 2019-09-06 at 23 15 15](https://user-images.githubusercontent.com/1198851/64470804-03785880-d0fe-11e9-8bf6-13343d8ca7cd.png) | ![Simulator Screen Shot - iPhone X - 2019-09-07 at 00 06 34](https://user-images.githubusercontent.com/1198851/64471212-71734e80-d103-11e9-8ae2-0c41f4a8a8c6.png) |
|---|---|---|
| _iOS 13 on iPhone X_ | _iOS 13 dark mode_ | _Dynamic type at XXXL_ |

| ![Simulator Screen Shot - iPad Pro (12 9-inch) (3rd generation) - 2019-09-07 at 00 13 17](https://user-images.githubusercontent.com/1198851/64471279-6ff65600-d104-11e9-86d9-b14204200a48.png) | ![](https://user-images.githubusercontent.com/1198851/64471187-09246d00-d103-11e9-9f7d-ac1098d7c54d.png) |
|---|---|
| _iOS 13 on iPad Pro 13”_ | _iOS 10 on iPhone SE_ |



/cc @mapbox/maps-ios 