### PR TITLE
[testflight] Add automatic CI deployment instructions

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -4,9 +4,17 @@ These instructions are intended for internal Mapbox developers.
 
 ## Build and deploy to TestFlight
 
+### Automatically on CI
+
+1. [Navigate to the `ios-sdk-examples` Bitrise project.](https://app.bitrise.io/app/9a144f2169b7c9e3)
+2. Manually start a new build on your desired branch (typically `ios-vX.X.X` or `master`) with the `testflight` workflow.
+3. Wait for the build to complete and for the TestFlight upload to process.
+
+### Manually
+
 1. Follow the [Getting Started](README.md#getting-started) instructions.
-1. `bundle exec fastlane beta`
-1. Wait 15-30 minutes for release notes to be added to the processed build.
+2. `bundle exec fastlane beta`
+3. Wait 15-30 minutes for release notes to be added to the processed build.
 
 ## Using TestFlight builds
 


### PR DESCRIPTION
Update the docs in the wake of https://github.com/mapbox/ios-sdk-examples/pull/339.

/cc @mapbox/maps-ios 