### PR TITLE
Add ShapeAnnotationsExample

### DIFF
--- a/Examples.xcodeproj/project.pbxproj
+++ b/Examples.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		05FA53AB1FE2FB9C001F3D7D /* CustomCalloutViewExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 05FA53AA1FE2FB9B001F3D7D /* CustomCalloutViewExample.m */; };
 		05FA53AD1FE2FBB3001F3D7D /* DefaultCalloutExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 05FA53AC1FE2FBB2001F3D7D /* DefaultCalloutExample.m */; };
 		075AFB7823393DBA0091FF0A /* example.geojson in Resources */ = {isa = PBXBuildFile; fileRef = 075AFB7723393DBA0091FF0A /* example.geojson */; };
+		0774A77423394B750038264E /* ShapeAnnotationsExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 0774A77323394B750038264E /* ShapeAnnotationsExample.m */; };
+		0774A77623394BFB0038264E /* ShapeAnnotationsExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0774A77523394BFB0038264E /* ShapeAnnotationsExample.swift */; };
 		07C138C01E6F646F00D6F678 /* MultipleShapesExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 07C138BF1E6F646F00D6F678 /* MultipleShapesExample.m */; };
 		07C138C21E6F65D000D6F678 /* MultipleShapesExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C138C11E6F65D000D6F678 /* MultipleShapesExample.swift */; };
 		07C138C41E721C8F00D6F678 /* DDSCircleLayerExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C138C31E721C8F00D6F678 /* DDSCircleLayerExample.swift */; };
@@ -199,6 +201,9 @@
 		05FA53AA1FE2FB9B001F3D7D /* CustomCalloutViewExample.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CustomCalloutViewExample.m; sourceTree = "<group>"; };
 		05FA53AC1FE2FBB2001F3D7D /* DefaultCalloutExample.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DefaultCalloutExample.m; sourceTree = "<group>"; };
 		075AFB7723393DBA0091FF0A /* example.geojson */ = {isa = PBXFileReference; lastKnownFileType = text; path = example.geojson; sourceTree = "<group>"; };
+		0774A77223394B750038264E /* ShapeAnnotationsExample.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ShapeAnnotationsExample.h; sourceTree = "<group>"; };
+		0774A77323394B750038264E /* ShapeAnnotationsExample.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ShapeAnnotationsExample.m; sourceTree = "<group>"; };
+		0774A77523394BFB0038264E /* ShapeAnnotationsExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShapeAnnotationsExample.swift; sourceTree = "<group>"; };
 		07C138BE1E6F646F00D6F678 /* MultipleShapesExample.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MultipleShapesExample.h; sourceTree = "<group>"; };
 		07C138BF1E6F646F00D6F678 /* MultipleShapesExample.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MultipleShapesExample.m; sourceTree = "<group>"; };
 		07C138C11E6F65D000D6F678 /* MultipleShapesExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipleShapesExample.swift; sourceTree = "<group>"; };
@@ -651,6 +656,8 @@
 				0543F64F1FE8698600D0AF54 /* Offline */,
 				0543F64D1FE8696800D0AF54 /* User interaction */,
 				9682472D1C5C226D00494AB8 /* Headers */,
+				0774A77223394B750038264E /* ShapeAnnotationsExample.h */,
+				0774A77323394B750038264E /* ShapeAnnotationsExample.m */,
 			);
 			name = "Objective-C";
 			sourceTree = "<group>";
@@ -667,6 +674,7 @@
 				0543F6411FE8675000D0AF54 /* Markers and callouts */,
 				0543F6471FE867C400D0AF54 /* Offline */,
 				0543F6451FE8679400D0AF54 /* User interaction */,
+				0774A77523394BFB0038264E /* ShapeAnnotationsExample.swift */,
 			);
 			name = Swift;
 			path = ../Swift;
@@ -1379,6 +1387,7 @@
 				05FA53A61FE2FA34001F3D7D /* OfflinePackExample.m in Sources */,
 				3E22EF521F8821F800605203 /* ImageSourceExample.m in Sources */,
 				05FA53A71FE2FA34001F3D7D /* StaticSnapshotExample.m in Sources */,
+				0774A77623394BFB0038264E /* ShapeAnnotationsExample.swift in Sources */,
 				3EBCD71C1DC28240001E342F /* CustomCalloutViewExample.swift in Sources */,
 				05FA53AD1FE2FBB3001F3D7D /* DefaultCalloutExample.m in Sources */,
 				CA39B2C1209B881300D37037 /* AnnotationViewExample+UITesting.m in Sources */,
@@ -1394,6 +1403,7 @@
 				969E7FDD1D25C31700663F84 /* UserTrackingModesExample.m in Sources */,
 				A42F4A5122EF9ACD005097F3 /* CacheManagementExample.swift in Sources */,
 				05FA53A11FE2FA1E001F3D7D /* PolygonPatternExample.m in Sources */,
+				0774A77423394B750038264E /* ShapeAnnotationsExample.m in Sources */,
 				3E3FB66E1F0588B3004512C6 /* BuildingLightExample.m in Sources */,
 				968247271C5C1DC700494AB8 /* CameraAnimationExample.m in Sources */,
 				CA39B2BF209B881300D37037 /* BuildingLightExample+UITesting.m in Sources */,

--- a/Examples/Examples.h
+++ b/Examples/Examples.h
@@ -56,6 +56,7 @@ extern NSString *const MBXExampleUserTrackingModes;
 extern NSString *const MBXExampleWebAPIData;
 extern NSString *const MBXExampleMissingIcons;
 extern NSString *const MBXExampleCacheManagement;
+extern NSString *const MBXExampleShapeAnnotations;
 
 @interface Examples : NSObject
 

--- a/Examples/Examples.m
+++ b/Examples/Examples.m
@@ -39,6 +39,7 @@
                     @{@"className": MBXExampleCustomCalloutView, @"title": @"Display custom views as callouts"},
                     @{@"className": MBXExampleWebAPIData, @"title": @"Dynamically style interactive points"},
                     @{@"className": MBXExampleUserLocationAnnotation, @"title": @"Customize the user location annotation"},
+                    @{@"className": MBXExampleShapeAnnotations, @"title": @"Add basic shape annotations with callouts"}
             ]
         },
         @{

--- a/Examples/ObjectiveC/ShapeAnnotationsExample.h
+++ b/Examples/ObjectiveC/ShapeAnnotationsExample.h
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ShapeAnnotationsExample : UIViewController
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Examples/ObjectiveC/ShapeAnnotationsExample.m
+++ b/Examples/ObjectiveC/ShapeAnnotationsExample.m
@@ -1,0 +1,91 @@
+#import "ShapeAnnotationsExample.h"
+@import Mapbox;
+
+NSString *const MBXExampleShapeAnnotations = @"ShapeAnnotationsExample";
+
+@interface ShapeAnnotationsExample () <MGLMapViewDelegate>
+
+@property MGLPointAnnotation *pointAnnotation;
+@property MGLPolyline *lineAnnotation;
+@property MGLPolygon *polygonAnnotation;
+
+@end
+
+@implementation ShapeAnnotationsExample
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.frame];
+    mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [mapView setCenterCoordinate:CLLocationCoordinate2DMake(45.520, -122.663) zoomLevel:13 animated:NO];
+    // Allow this ViewController class to be the reciever of `MGLMapViewDelegate` events.
+    mapView.delegate = self;
+    [self.view addSubview:mapView];
+
+    [self setupAnnotations];
+
+    // Add all three shapes to the map.
+    [mapView addAnnotations:@[self.pointAnnotation, self.lineAnnotation, self.polygonAnnotation]];
+}
+
+// Allows callouts to be displayed when the annotation is selected.
+- (BOOL)mapView:(MGLMapView *)mapView annotationCanShowCallout:(id<MGLAnnotation>)annotation {
+    return YES;
+}
+
+// Assigns a fill color for the polygon annotation.
+- (UIColor *)mapView:(MGLMapView *)mapView fillColorForPolygonAnnotation:(MGLPolygon *)annotation {
+    return [UIColor colorWithRed: 1.00 green: 0.96 blue: 0.00 alpha: 0.4];
+}
+
+// Assigns a stroke or "outline" color for non-point annotations.
+-(UIColor *)mapView:(MGLMapView *)mapView strokeColorForShapeAnnotation:(MGLShape *)annotation {
+    return [UIColor colorWithRed: 0.00 green: 0.46 blue: 1.00 alpha: 1.0];
+}
+
+// Assigns a width for to the line annotation.
+- (CGFloat)mapView:(MGLMapView *)mapView lineWidthForPolylineAnnotation:(MGLPolyline *)annotation {
+    return 8.0;
+}
+
+- (void)setupAnnotations {
+    // Three shapes annotations are created below: a point, line, and a polygon.
+    MGLPointAnnotation *pointAnnotation = [[MGLPointAnnotation alloc] init];
+    pointAnnotation.coordinate = CLLocationCoordinate2DMake(45.531, -122.666);
+    pointAnnotation.title = @"Event venue";
+
+     // Since structs aren't supported in Objective-C arrays,
+     // store coordinates in a compatible C++ array instead.
+    CLLocationCoordinate2D lineCoordinates[] = {
+        CLLocationCoordinate2DMake(45.526, -122.677),
+        CLLocationCoordinate2DMake(45.523, -122.677),
+        CLLocationCoordinate2DMake(45.523, -122.674),
+        CLLocationCoordinate2DMake(45.522, -122.674),
+        CLLocationCoordinate2DMake(45.518, -122.676),
+        CLLocationCoordinate2DMake(45.517, -122.673),
+        CLLocationCoordinate2DMake(45.513, -122.676)
+    };
+
+    NSUInteger lineCoordinateCount = sizeof(lineCoordinates) / sizeof(CLLocationCoordinate2D);
+    MGLPolyline *lineAnnotation = [MGLPolyline polylineWithCoordinates:lineCoordinates count:lineCoordinateCount];
+    lineAnnotation.title = @"Parade route";
+
+    CLLocationCoordinate2D polygonCoordinates[] = {
+        CLLocationCoordinate2DMake(45.512, -122.663),
+        CLLocationCoordinate2DMake(45.512, -122.654),
+        CLLocationCoordinate2DMake(45.522, -122.654),
+        CLLocationCoordinate2DMake(45.522, -122.663),
+        CLLocationCoordinate2DMake(45.512, -122.663)
+    };
+
+    NSUInteger polygonCoordinateCount = sizeof(polygonCoordinates) / sizeof(CLLocationCoordinate2D);
+    MGLPolygon *polygonAnnotation = [MGLPolygon polygonWithCoordinates:polygonCoordinates count:polygonCoordinateCount];
+    polygonAnnotation.title = @"Limited parking";
+
+    self.pointAnnotation = pointAnnotation;
+    self.lineAnnotation = lineAnnotation;
+    self.polygonAnnotation = polygonAnnotation;
+}
+
+@end

--- a/Examples/Swift/ShapeAnnotationsExample.swift
+++ b/Examples/Swift/ShapeAnnotationsExample.swift
@@ -1,0 +1,84 @@
+import UIKit
+import Mapbox
+
+@objc(ShapeAnnotationsExample_Swift)
+
+class ShapeAnnotationsExample_Swift: UIViewController {
+
+    var pointCoordinate: CLLocationCoordinate2D!
+    var lineCoordinates = [CLLocationCoordinate2D]()
+    var polygonCoordinates = [CLLocationCoordinate2D]()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let mapView = MGLMapView(frame: self.view.frame)
+        mapView.setCenter(CLLocationCoordinate2D(latitude: 45.520, longitude: -122.668), zoomLevel: 13, animated: false)
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        // Allow this ViewController class to be the reciever of `MGLMapViewDelegate` events.
+        mapView.delegate = self
+        view.addSubview(mapView)
+
+        setupCoordinates()
+
+        // Three shapes annotations are created below: a point, line, and a polygon.
+        let pointAnnnotation = MGLPointAnnotation()
+        pointAnnnotation.coordinate = pointCoordinate
+        // This text will appear in the callout when the
+        // shape is selected.
+        pointAnnnotation.title = "Event venue"
+
+        let lineAnnotation = MGLPolyline(coordinates: lineCoordinates, count: UInt(lineCoordinates.count))
+        lineAnnotation.title = "Parade route"
+
+        let polygonAnnotation = MGLPolygon(coordinates: polygonCoordinates, count: UInt(polygonCoordinates.count))
+        polygonAnnotation.title = "Limited parking"
+
+        // Add all three annotations to the map.
+        mapView.addAnnotations([pointAnnnotation, lineAnnotation, polygonAnnotation])
+    }
+
+    func setupCoordinates() {
+        pointCoordinate = CLLocationCoordinate2D(latitude: 45.531, longitude: -122.666)
+
+        lineCoordinates = [
+          CLLocationCoordinate2D(latitude: 45.526, longitude: -122.677),
+          CLLocationCoordinate2D(latitude: 45.523, longitude: -122.677),
+          CLLocationCoordinate2D(latitude: 45.523, longitude: -122.674),
+          CLLocationCoordinate2D(latitude: 45.522, longitude: -122.674),
+          CLLocationCoordinate2D(latitude: 45.518, longitude: -122.676),
+          CLLocationCoordinate2D(latitude: 45.517, longitude: -122.673),
+          CLLocationCoordinate2D(latitude: 45.513, longitude: -122.676)
+        ]
+
+        polygonCoordinates = [
+          CLLocationCoordinate2D(latitude: 45.512, longitude: -122.663),
+          CLLocationCoordinate2D(latitude: 45.512, longitude: -122.654),
+          CLLocationCoordinate2D(latitude: 45.522, longitude: -122.654),
+          CLLocationCoordinate2D(latitude: 45.522, longitude: -122.663),
+          CLLocationCoordinate2D(latitude: 45.512, longitude: -122.663)
+        ]
+    }
+}
+
+extension ShapeAnnotationsExample_Swift: MGLMapViewDelegate {
+    // Allows callouts to be displayed when the annotation is selected.
+    func mapView(_ mapView: MGLMapView, annotationCanShowCallout annotation: MGLAnnotation) -> Bool {
+        return true
+    }
+
+    // Assigns a fill color for the polygon annotation.
+    func mapView(_ mapView: MGLMapView, fillColorForPolygonAnnotation annotation: MGLPolygon) -> UIColor {
+        return UIColor(red: 1.00, green: 0.96, blue: 0.00, alpha: 0.4)
+    }
+
+    // Assigns a stroke or "outline" color for non-point annotations.
+    func mapView(_ mapView: MGLMapView, strokeColorForShapeAnnotation annotation: MGLShape) -> UIColor {
+        return UIColor(red: 0.00, green: 0.46, blue: 1.00, alpha: 1.0)
+    }
+
+    // Assigns a width for to the line annotation.
+    func mapView(_ mapView: MGLMapView, lineWidthForPolylineAnnotation annotation: MGLPolyline) -> CGFloat {
+        return 8.0
+    }
+}


### PR DESCRIPTION
Adds a new example to showcase how to add three types of annotations to one map, all with callouts:

<img height="500" alt="Screenshot 2019-09-19 16 28 14" src="https://user-images.githubusercontent.com/10850812/65288524-fa26bd00-dafb-11e9-996e-3f3d7dc5f821.png">

This example was made in part to subsume `DefaultCalloutExample`,  `PolygonAnnotationExample`, and `LineAnnotationGeoJSONExample` (although this example doesn't add data from parsed GeoJSON, we have other examples of this already).