### PR TITLE
Work-around iOS 13 navigation controller rotation bug

### DIFF
--- a/Examples/ExamplesContainerViewController.m
+++ b/Examples/ExamplesContainerViewController.m
@@ -9,8 +9,8 @@
 #import "ExamplesContainerViewController.h"
 
 @interface ExamplesContainerViewController ()
-
 @end
+
 @implementation ExamplesContainerViewController
 
 - (void)viewDidLoad {
@@ -35,7 +35,6 @@
     }
 
     self.navigationController.hidesBarsOnSwipe = YES;
-    self.navigationController.hidesBarsWhenVerticallyCompact = YES;
 }
 
 @end


### PR DESCRIPTION
Fixes #361 by removing [`UINavigationController.hidesBarsWhenVerticallyCompact`](https://developer.apple.com/documentation/uikit/uinavigationcontroller/1621869-hidesbarswhenverticallycompact), which appears to have issues in iOS 13.

/cc @captainbarbosa @jmkiley 