### PR TITLE
Adds / simplifies mapview ornaments layout example

### DIFF
--- a/Examples.xcodeproj/project.pbxproj
+++ b/Examples.xcodeproj/project.pbxproj
@@ -92,6 +92,8 @@
 		64CF97101DF224E400C3C27B /* ThirdPartyVectorStyleExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CF970F1DF224E400C3C27B /* ThirdPartyVectorStyleExample.swift */; };
 		64CF97121DF224F600C3C27B /* RasterImageryExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64CF97111DF224F600C3C27B /* RasterImageryExample.swift */; };
 		64CF97171DF2251500C3C27B /* RasterImageryExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 64CF97161DF2251500C3C27B /* RasterImageryExample.m */; };
+		6FAC014522718DF300F7FA18 /* OrnamentsLayoutExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FAC014422718DF300F7FA18 /* OrnamentsLayoutExample.m */; };
+		6FAC014722718FCC00F7FA18 /* OrnamentsLayoutExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FAC014622718FCC00F7FA18 /* OrnamentsLayoutExample.swift */; };
 		960A21611D344F9F00BB348B /* DraggableAnnotationViewExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 960A21601D344F9F00BB348B /* DraggableAnnotationViewExample.m */; };
 		961962911C581700002D3DAB /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 961962901C581700002D3DAB /* main.m */; };
 		961962941C581700002D3DAB /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 961962931C581700002D3DAB /* AppDelegate.m */; };
@@ -288,6 +290,9 @@
 		64CF97111DF224F600C3C27B /* RasterImageryExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RasterImageryExample.swift; sourceTree = "<group>"; };
 		64CF97161DF2251500C3C27B /* RasterImageryExample.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RasterImageryExample.m; sourceTree = "<group>"; };
 		64CF97191DF2252C00C3C27B /* RasterImageryExample.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RasterImageryExample.h; sourceTree = "<group>"; };
+		6FAC014322718DD100F7FA18 /* OrnamentsLayoutExample.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OrnamentsLayoutExample.h; sourceTree = "<group>"; };
+		6FAC014422718DF300F7FA18 /* OrnamentsLayoutExample.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OrnamentsLayoutExample.m; sourceTree = "<group>"; };
+		6FAC014622718FCC00F7FA18 /* OrnamentsLayoutExample.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrnamentsLayoutExample.swift; sourceTree = "<group>"; };
 		7556D44879C1E2866B0355B8 /* Pods-ExamplesTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExamplesTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ExamplesTests/Pods-ExamplesTests.release.xcconfig"; sourceTree = "<group>"; };
 		7692D1D792EB3849E8754E6B /* Pods_ExamplesUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ExamplesUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7823ECBC65EEAAC3EA0B6E42 /* Pods-DocsCode.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DocsCode.release.xcconfig"; path = "Pods/Target Support Files/Pods-DocsCode/Pods-DocsCode.release.xcconfig"; sourceTree = "<group>"; };
@@ -492,6 +497,7 @@
 				3EBCD7121DC28240001E342F /* PointConversionExample.swift */,
 				646B62961DEF6DAF000AA523 /* ShowHideLayerExample.swift */,
 				3EBCD7151DC28240001E342F /* UserTrackingModesExample.swift */,
+				6FAC014622718FCC00F7FA18 /* OrnamentsLayoutExample.swift */,
 			);
 			name = "User interaction";
 			sourceTree = "<group>";
@@ -586,6 +592,7 @@
 				96BAED2D1FE304DD00A58BEB /* PointConversionExample.m */,
 				646B629B1DEF6DF1000AA523 /* ShowHideLayerExample.m */,
 				969E7FDC1D25C31700663F84 /* UserTrackingModesExample.m */,
+				6FAC014422718DF300F7FA18 /* OrnamentsLayoutExample.m */,
 			);
 			name = "User interaction";
 			sourceTree = "<group>";
@@ -795,6 +802,7 @@
 				3E44BA56203B54260072DE4B /* MultipleImagesExample.h */,
 				07C138BE1E6F646F00D6F678 /* MultipleShapesExample.h */,
 				96115A661CAD4E1C000963B8 /* OfflinePackExample.h */,
+				6FAC014322718DD100F7FA18 /* OrnamentsLayoutExample.h */,
 				968247281C5C1FF800494AB8 /* PointConversionExample.h */,
 				055ABCBF1EFB139C0063BACA /* PolygonPatternExample.h */,
 				64CF97191DF2252C00C3C27B /* RasterImageryExample.h */,
@@ -1338,6 +1346,7 @@
 				07C138C21E6F65D000D6F678 /* MultipleShapesExample.swift in Sources */,
 				3EBCD7161DC28240001E342F /* AnnotationViewExample.swift in Sources */,
 				961962941C581700002D3DAB /* AppDelegate.m in Sources */,
+				6FAC014522718DF300F7FA18 /* OrnamentsLayoutExample.m in Sources */,
 				3EBCD71B1DC28240001E342F /* CustomCalloutView.swift in Sources */,
 				07C138C01E6F646F00D6F678 /* MultipleShapesExample.m in Sources */,
 				3EBCD7291DC28240001E342F /* UserTrackingModesExample.swift in Sources */,
@@ -1373,6 +1382,8 @@
 				3E44BA55203B54120072DE4B /* MultipleImagesExample.swift in Sources */,
 				3E1806101EAA800A004DB131 /* UserLocationAnnotationExample.m in Sources */,
 				961962911C581700002D3DAB /* main.m in Sources */,
+				6FAC014722718FCC00F7FA18 /* OrnamentsLayoutExample.swift in Sources */,
+				05FA53A21FE2FA1E001F3D7D /* PolygonAnnotationExample.m in Sources */,
 				1F0701552252D2090045E061 /* TextFormattingExample.swift in Sources */,
 				3EBCD7251DC28240001E342F /* OfflinePackExample.swift in Sources */,
 				3E3BFAD91E81D7A300D0BEA1 /* FeatureSelectionExample.swift in Sources */,

--- a/Examples/Examples.h
+++ b/Examples/Examples.h
@@ -56,6 +56,7 @@ extern NSString *const MBXExampleWebAPIData;
 extern NSString *const MBXExampleMissingIcons;
 extern NSString *const MBXExampleCacheManagement;
 extern NSString *const MBXExampleShapeAnnotations;
+extern NSString *const MBXExampleOrnamentsLayout;
 
 @interface Examples : NSObject
 

--- a/Examples/Examples.m
+++ b/Examples/Examples.m
@@ -58,7 +58,8 @@
                     @{@"className": MBXExampleShowHideLayer, @"title": @"Show and hide a layer"},
                     @{@"className": MBXExampleFeatureSelection, @"title": @"Select a feature within a layer"},
                     @{@"className": MBXExampleUserTrackingModes, @"title": @"Switch between user tracking modes"},
-            ]
+                    @{@"className": MBXExampleOrnamentsLayout, @"title": @"Ornaments layout"}
+                    ]
         },
         @{
             @"title": @"Dynamic styling",

--- a/Examples/ObjectiveC/Headers/OrnamentsLayoutExample.h
+++ b/Examples/ObjectiveC/Headers/OrnamentsLayoutExample.h
@@ -1,0 +1,5 @@
+#import <UIKit/UIKit.h>
+
+@interface OrnamentsLayoutExample : UIViewController
+
+@end

--- a/Examples/ObjectiveC/OrnamentsLayoutExample.m
+++ b/Examples/ObjectiveC/OrnamentsLayoutExample.m
@@ -2,6 +2,7 @@
 
 @import Mapbox;
 
+// Ornament positions matrix arry, this example will demonstrate how ornament looks like in different positions.
 NSString *const MBXExampleOrnamentsLayout = @"OrnamentsLayoutExample";
 MGLOrnamentPosition ornamentPositions[4][4] = {
     {
@@ -57,11 +58,15 @@ MGLOrnamentPosition ornamentPositions[4][4] = {
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
+    [super viewDidDisappear:animated];
+    // Stop the timer if the view was removed.
     [self.timer invalidate];
     self.timer = nil;
 }
 
 - (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    // Create a timer to update ornaments position every second.
     self.timer = [NSTimer scheduledTimerWithTimeInterval:1
                                                   target:self
                                                 selector:@selector(onTimerTick)
@@ -70,8 +75,9 @@ MGLOrnamentPosition ornamentPositions[4][4] = {
 }
 
 - (void)updateOrnamentsPosition {
-
+    // Get position matrix for current turn. We mod 4 to roll over the matrix array.
     MGLOrnamentPosition *currentPosition = ornamentPositions[_currentPositionIndex % 4];
+    // Update ornaments position with position matrix.
     self.mapView.scaleBarPosition = currentPosition[0];
     self.mapView.compassViewPosition = currentPosition[1];
     self.mapView.logoViewPosition = currentPosition[2];

--- a/Examples/ObjectiveC/OrnamentsLayoutExample.m
+++ b/Examples/ObjectiveC/OrnamentsLayoutExample.m
@@ -4,38 +4,8 @@
 
 // Ornament positions matrix arry, this example will demonstrate how ornament looks like in different positions.
 NSString *const MBXExampleOrnamentsLayout = @"OrnamentsLayoutExample";
-MGLOrnamentPosition ornamentPositions[4][4] = {
-    {
-        MGLOrnamentPositionTopLeft,
-        MGLOrnamentPositionTopRight,
-        MGLOrnamentPositionBottomRight,
-        MGLOrnamentPositionBottomLeft
-    },
-    {
-        MGLOrnamentPositionTopRight,
-        MGLOrnamentPositionBottomRight,
-        MGLOrnamentPositionBottomLeft,
-        MGLOrnamentPositionTopLeft
-    },
-    {
-        MGLOrnamentPositionBottomRight,
-        MGLOrnamentPositionBottomLeft,
-        MGLOrnamentPositionTopLeft,
-        MGLOrnamentPositionTopRight
-    },
-    {
-        MGLOrnamentPositionBottomLeft,
-        MGLOrnamentPositionTopLeft,
-        MGLOrnamentPositionTopRight,
-        MGLOrnamentPositionBottomRight
-    }
-};
 
 @interface OrnamentsLayoutExample ()<MGLMapViewDelegate>
-
-@property (nonatomic) MGLMapView *mapView;
-@property (nonatomic) NSTimer *timer;
-@property (nonatomic) NSInteger currentPositionIndex;
 
 @end
 
@@ -44,49 +14,28 @@ MGLOrnamentPosition ornamentPositions[4][4] = {
 - (void)viewDidLoad {
     [super viewDidLoad];
 
+    // Initialize mapView with some center
     MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
     mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     [mapView setCenterCoordinate:CLLocationCoordinate2DMake(39.915143, 116.404053)
                        zoomLevel:16
                        direction:30
                         animated:NO];
+    
+    // Configure mapView to show the scale and always display the compass
     mapView.delegate = self;
     mapView.showsScale = YES;
-    [self.view addSubview:mapView];
+    mapView.compassView.compassVisibility = MGLOrnamentVisibilityVisible;
     
-    self.mapView = mapView;
-}
-
-- (void)viewDidDisappear:(BOOL)animated {
-    [super viewDidDisappear:animated];
-    // Stop the timer if the view was removed.
-    [self.timer invalidate];
-    self.timer = nil;
-}
-
-- (void)viewDidAppear:(BOOL)animated {
-    [super viewDidAppear:animated];
-    // Create a timer to update ornaments position every second.
-    self.timer = [NSTimer scheduledTimerWithTimeInterval:1
-                                                  target:self
-                                                selector:@selector(onTimerTick)
-                                                userInfo:nil
-                                                 repeats:YES];
-}
-
-- (void)updateOrnamentsPosition {
-    // Get position matrix for current turn. We mod 4 to roll over the matrix array.
-    MGLOrnamentPosition *currentPosition = ornamentPositions[_currentPositionIndex % 4];
-    // Update ornaments position with position matrix.
-    self.mapView.scaleBarPosition = currentPosition[0];
-    self.mapView.compassViewPosition = currentPosition[1];
-    self.mapView.logoViewPosition = currentPosition[2];
-    self.mapView.attributionButtonPosition = currentPosition[3];
-}
-
-- (void)onTimerTick {
-    self.currentPositionIndex ++;
-    [self updateOrnamentsPosition];
+    // Set positions of various ornaments via `MGLOrnamentPosition` enum.
+    // NOTE: You can be more prescriptive about where the ornaments are positioned by using
+    // the `scaleBarMargins` , `compassViewMargins`, `logoViewMargins` and `attributionButtonMargins` properties.
+    mapView.scaleBarPosition = MGLOrnamentPositionTopLeft;
+    mapView.compassViewPosition = MGLOrnamentPositionTopRight;
+    mapView.logoViewPosition = MGLOrnamentPositionBottomLeft;
+    mapView.attributionButtonPosition = MGLOrnamentPositionBottomRight;
+    
+    [self.view addSubview:mapView];
 }
 
 @end

--- a/Examples/ObjectiveC/OrnamentsLayoutExample.m
+++ b/Examples/ObjectiveC/OrnamentsLayoutExample.m
@@ -2,7 +2,6 @@
 
 @import Mapbox;
 
-// Ornament positions matrix arry, this example will demonstrate how ornament looks like in different positions.
 NSString *const MBXExampleOrnamentsLayout = @"OrnamentsLayoutExample";
 
 @interface OrnamentsLayoutExample ()<MGLMapViewDelegate>
@@ -14,7 +13,7 @@ NSString *const MBXExampleOrnamentsLayout = @"OrnamentsLayoutExample";
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-    // Initialize mapView with some center
+    // Initialize mapView with some center.
     MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
     mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     [mapView setCenterCoordinate:CLLocationCoordinate2DMake(39.915143, 116.404053)
@@ -22,7 +21,7 @@ NSString *const MBXExampleOrnamentsLayout = @"OrnamentsLayoutExample";
                        direction:30
                         animated:NO];
     
-    // Configure mapView to show the scale and always display the compass
+    // Configure mapView to show the scale and always display the compass.
     mapView.delegate = self;
     mapView.showsScale = YES;
     mapView.compassView.compassVisibility = MGLOrnamentVisibilityVisible;
@@ -30,10 +29,10 @@ NSString *const MBXExampleOrnamentsLayout = @"OrnamentsLayoutExample";
     // Set positions of various ornaments via `MGLOrnamentPosition` enum.
     // NOTE: You can be more prescriptive about where the ornaments are positioned by using
     // the `scaleBarMargins` , `compassViewMargins`, `logoViewMargins` and `attributionButtonMargins` properties.
-    mapView.scaleBarPosition = MGLOrnamentPositionTopLeft;
-    mapView.compassViewPosition = MGLOrnamentPositionTopRight;
-    mapView.logoViewPosition = MGLOrnamentPositionBottomLeft;
-    mapView.attributionButtonPosition = MGLOrnamentPositionBottomRight;
+    mapView.scaleBarPosition = MGLOrnamentPositionTopRight;
+    mapView.compassViewPosition = MGLOrnamentPositionTopLeft;
+    mapView.logoViewPosition = MGLOrnamentPositionBottomRight;
+    mapView.attributionButtonPosition = MGLOrnamentPositionBottomLeft;
     
     [self.view addSubview:mapView];
 }

--- a/Examples/ObjectiveC/OrnamentsLayoutExample.m
+++ b/Examples/ObjectiveC/OrnamentsLayoutExample.m
@@ -1,0 +1,86 @@
+#import "OrnamentsLayoutExample.h"
+
+@import Mapbox;
+
+NSString *const MBXExampleOrnamentsLayout = @"OrnamentsLayoutExample";
+MGLOrnamentPosition ornamentPositions[4][4] = {
+    {
+        MGLOrnamentPositionTopLeft,
+        MGLOrnamentPositionTopRight,
+        MGLOrnamentPositionBottomRight,
+        MGLOrnamentPositionBottomLeft
+    },
+    {
+        MGLOrnamentPositionTopRight,
+        MGLOrnamentPositionBottomRight,
+        MGLOrnamentPositionBottomLeft,
+        MGLOrnamentPositionTopLeft
+    },
+    {
+        MGLOrnamentPositionBottomRight,
+        MGLOrnamentPositionBottomLeft,
+        MGLOrnamentPositionTopLeft,
+        MGLOrnamentPositionTopRight
+    },
+    {
+        MGLOrnamentPositionBottomLeft,
+        MGLOrnamentPositionTopLeft,
+        MGLOrnamentPositionTopRight,
+        MGLOrnamentPositionBottomRight
+    }
+};
+
+@interface OrnamentsLayoutExample ()<MGLMapViewDelegate>
+
+@property (nonatomic) MGLMapView *mapView;
+@property (nonatomic) NSTimer *timer;
+@property (nonatomic) NSInteger currentPositionIndex;
+
+@end
+
+@implementation OrnamentsLayoutExample
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
+    mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [mapView setCenterCoordinate:CLLocationCoordinate2DMake(39.915143, 116.404053)
+                       zoomLevel:16
+                       direction:30
+                        animated:NO];
+    mapView.delegate = self;
+    mapView.showsScale = YES;
+    [self.view addSubview:mapView];
+    
+    self.mapView = mapView;
+}
+
+- (void)viewDidDisappear:(BOOL)animated {
+    [self.timer invalidate];
+    self.timer = nil;
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    self.timer = [NSTimer scheduledTimerWithTimeInterval:1
+                                                  target:self
+                                                selector:@selector(onTimerTick)
+                                                userInfo:nil
+                                                 repeats:YES];
+}
+
+- (void)updateOrnamentsPosition {
+
+    MGLOrnamentPosition *currentPosition = ornamentPositions[_currentPositionIndex % 4];
+    self.mapView.scaleBarPosition = currentPosition[0];
+    self.mapView.compassViewPosition = currentPosition[1];
+    self.mapView.logoViewPosition = currentPosition[2];
+    self.mapView.attributionButtonPosition = currentPosition[3];
+}
+
+- (void)onTimerTick {
+    self.currentPositionIndex ++;
+    [self updateOrnamentsPosition];
+}
+
+@end

--- a/Examples/Swift/OrnamentsLayoutExample.swift
+++ b/Examples/Swift/OrnamentsLayoutExample.swift
@@ -7,12 +7,12 @@ class OrnamentsLayoutExample_Swift: UIViewController, MGLMapViewDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Initializing map view
+        // Initializing map view and setting center.
         mapView = MGLMapView(frame: view.bounds)
         mapView.setCenter(CLLocationCoordinate2DMake(39.915143, 116.404053), zoomLevel: 16, direction: 30, animated: false)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         
-        // Configure mapView to show the scale and always display the compass
+        // Configure mapView to show the scale and always display the compass.
         mapView.delegate = self
         mapView.showsScale = true
         mapView.compassView.compassVisibility = .visible
@@ -20,10 +20,10 @@ class OrnamentsLayoutExample_Swift: UIViewController, MGLMapViewDelegate {
         // Set positions of various ornaments using the `MGLOrnamentPosition` enum.
         // NOTE: You can be more prescriptive about where the ornaments are positioned by using
         // the `scaleBarMargins` , `compassViewMargins`, `logoViewMargins` and `attributionButtonMargins` properties.
-        mapView.scaleBarPosition = .topLeft
-        mapView.compassViewPosition = .topRight
-        mapView.logoViewPosition = .bottomLeft
-        mapView.attributionButtonPosition = .bottomRight
+        mapView.scaleBarPosition = .topRight
+        mapView.compassViewPosition = .topLeft
+        mapView.logoViewPosition = .bottomRight
+        mapView.attributionButtonPosition = .bottomLeft
 
         view.addSubview(mapView)
     }

--- a/Examples/Swift/OrnamentsLayoutExample.swift
+++ b/Examples/Swift/OrnamentsLayoutExample.swift
@@ -1,6 +1,7 @@
 import Mapbox
 
-let oramentPositions: [[MGLOrnamentPosition]] = [
+// Ornament positions matrix array, this example will demonstrate how ornament looks like in different positions.
+let ornamentPosition: [[MGLOrnamentPosition]] = [
     [.topLeft, .topRight, .bottomRight, .bottomLeft],
     [.topRight, .bottomRight, .bottomLeft, .topLeft],
     [.bottomRight, .bottomLeft, .topLeft, .topRight],
@@ -26,20 +27,25 @@ class OrnamentsLayoutExample_Swift: UIViewController, MGLMapViewDelegate {
     }
 
     override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        // Create a timer to update ornaments position every second.
         self.timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(onTimerTick), userInfo: nil, repeats: true)
     }
 
     override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         guard let timer = self.timer else {
             return
         }
+        // Stop the timer if the view was removed.
         timer.invalidate()
         self.timer = nil
     }
 
     func updateOrnamentsPosition() {
-
-        let positions = oramentPositions[self.currentPositionIndex%4]
+        // Get position matrix for current turn. We mod 4 to roll over the matrix array.
+        let positions = ornamentPosition[self.currentPositionIndex%4]
+        // Update ornaments position with position matrix.
         self.mapView.scaleBarPosition = positions[0]
         self.mapView.compassViewPosition = positions[1]
         self.mapView.logoViewPosition = positions[2]

--- a/Examples/Swift/OrnamentsLayoutExample.swift
+++ b/Examples/Swift/OrnamentsLayoutExample.swift
@@ -1,0 +1,53 @@
+import Mapbox
+
+let oramentPositions: [[MGLOrnamentPosition]] = [
+    [.topLeft, .topRight, .bottomRight, .bottomLeft],
+    [.topRight, .bottomRight, .bottomLeft, .topLeft],
+    [.bottomRight, .bottomLeft, .topLeft, .topRight],
+    [.bottomLeft, .topLeft, .topRight, .bottomRight]
+]
+
+@objc(OrnamentsLayoutExample_Swift)
+class OrnamentsLayoutExample_Swift: UIViewController, MGLMapViewDelegate {
+    var mapView: MGLMapView!
+    var timer: Timer?
+    var currentPositionIndex: Int = 0
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        mapView = MGLMapView(frame: view.bounds)
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        mapView.showsScale = true
+        mapView.setCenter(CLLocationCoordinate2DMake(39.915143, 116.404053), zoomLevel: 16, direction: 30, animated: false)
+        self.view.addSubview(mapView)
+
+        mapView.delegate = self
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        self.timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(onTimerTick), userInfo: nil, repeats: true)
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        guard let timer = self.timer else {
+            return
+        }
+        timer.invalidate()
+        self.timer = nil
+    }
+
+    func updateOrnamentsPosition() {
+
+        let positions = oramentPositions[self.currentPositionIndex%4]
+        self.mapView.scaleBarPosition = positions[0]
+        self.mapView.compassViewPosition = positions[1]
+        self.mapView.logoViewPosition = positions[2]
+        self.mapView.attributionButtonPosition = positions[3]
+    }
+
+    @objc func onTimerTick() {
+        self.currentPositionIndex += 1
+        self.updateOrnamentsPosition()
+    }
+}

--- a/Examples/Swift/OrnamentsLayoutExample.swift
+++ b/Examples/Swift/OrnamentsLayoutExample.swift
@@ -1,59 +1,30 @@
 import Mapbox
 
-// Ornament positions matrix array, this example will demonstrate how ornament looks like in different positions.
-let ornamentPosition: [[MGLOrnamentPosition]] = [
-    [.topLeft, .topRight, .bottomRight, .bottomLeft],
-    [.topRight, .bottomRight, .bottomLeft, .topLeft],
-    [.bottomRight, .bottomLeft, .topLeft, .topRight],
-    [.bottomLeft, .topLeft, .topRight, .bottomRight]
-]
-
 @objc(OrnamentsLayoutExample_Swift)
 class OrnamentsLayoutExample_Swift: UIViewController, MGLMapViewDelegate {
-    var mapView: MGLMapView!
-    var timer: Timer?
-    var currentPositionIndex: Int = 0
+    private var mapView: MGLMapView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        // Initializing map view
         mapView = MGLMapView(frame: view.bounds)
-        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        mapView.showsScale = true
         mapView.setCenter(CLLocationCoordinate2DMake(39.915143, 116.404053), zoomLevel: 16, direction: 30, animated: false)
-        self.view.addSubview(mapView)
-
+        mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        
+        // Configure mapView to show the scale and always display the compass
         mapView.delegate = self
-    }
+        mapView.showsScale = true
+        mapView.compassView.compassVisibility = .visible
+        
+        // Set positions of various ornaments using the `MGLOrnamentPosition` enum.
+        // NOTE: You can be more prescriptive about where the ornaments are positioned by using
+        // the `scaleBarMargins` , `compassViewMargins`, `logoViewMargins` and `attributionButtonMargins` properties.
+        mapView.scaleBarPosition = .topLeft
+        mapView.compassViewPosition = .topRight
+        mapView.logoViewPosition = .bottomLeft
+        mapView.attributionButtonPosition = .bottomRight
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        // Create a timer to update ornaments position every second.
-        self.timer = Timer.scheduledTimer(timeInterval: 1, target: self, selector: #selector(onTimerTick), userInfo: nil, repeats: true)
-    }
-
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        guard let timer = self.timer else {
-            return
-        }
-        // Stop the timer if the view was removed.
-        timer.invalidate()
-        self.timer = nil
-    }
-
-    func updateOrnamentsPosition() {
-        // Get position matrix for current turn. We mod 4 to roll over the matrix array.
-        let positions = ornamentPosition[self.currentPositionIndex%4]
-        // Update ornaments position with position matrix.
-        self.mapView.scaleBarPosition = positions[0]
-        self.mapView.compassViewPosition = positions[1]
-        self.mapView.logoViewPosition = positions[2]
-        self.mapView.attributionButtonPosition = positions[3]
-    }
-
-    @objc func onTimerTick() {
-        self.currentPositionIndex += 1
-        self.updateOrnamentsPosition()
+        view.addSubview(mapView)
     }
 }


### PR DESCRIPTION
This PR builds on @lloydsheng 's work in #297  for the ornaments layout example by addressing the review comments. 

Mainly, this PR simplifies the example a bit and adds associated documentation to guide the reader along as they look for examples to manipulate the ornaments in their map views.