### PR TITLE
Remove example transfuser comments in tutorial demos

### DIFF
--- a/DocsCode/DDSCircleLayerTutorial/DDSCircleLayerTutorialViewController.m
+++ b/DocsCode/DDSCircleLayerTutorial/DDSCircleLayerTutorialViewController.m
@@ -11,7 +11,6 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    // #-code-snippet: expressions initialize-map-objc
     MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds styleURL: [MGLStyle lightStyleURL]];
     
     mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
@@ -22,13 +21,11 @@
     
     [self.view addSubview:mapView];
     mapView.delegate = self;
-    // #-end-code-snippet: expressions initialize-map-objc
 }
 
 
 - (void)mapView:(MGLMapView *)mapView didFinishLoadingStyle:(MGLStyle *)style {
     
-    // #-code-snippet: expressions add-layer-objc
     MGLSource *source = [[MGLVectorTileSource alloc] initWithIdentifier:@"historical-places" configurationURL:[NSURL URLWithString:@"mapbox://examples.5zzwbooj"]];
     
     [mapView.style addSource:source];
@@ -49,7 +46,6 @@
     layer.circleRadius = [NSExpression expressionWithFormat:@"mgl_interpolate:withCurveType:parameters:stops:(Constructi, 'linear', nil, %@)", zoomStops];
     
     [mapView.style addLayer:layer];
-    // #-end-code-snippet: expressions add-layer-objc
 }
 
 @end

--- a/DocsCode/DDSCircleLayerTutorial/DDSCircleLayerTutorialViewController.swift
+++ b/DocsCode/DDSCircleLayerTutorial/DDSCircleLayerTutorialViewController.swift
@@ -6,7 +6,6 @@ class DDSCircleLayerTutorialViewController: UIViewController, MGLMapViewDelegate
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // #-code-snippet: expressions initialize-map-swift
         let mapView = MGLMapView(frame: view.bounds)
         mapView.styleURL = MGLStyle.lightStyleURL
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
@@ -15,12 +14,10 @@ class DDSCircleLayerTutorialViewController: UIViewController, MGLMapViewDelegate
 
         mapView.delegate = self
         view.addSubview(mapView)
-        // #-end-code-snippet: expressions initialize-map-swift
     }
 
     func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
 
-        // #-code-snippet: expressions add-layer-swift
         let source = MGLVectorTileSource(identifier: "historical-places", configurationURL: URL(string: "mapbox://examples.5zzwbooj")!)
 
         style.addSource(source)
@@ -41,6 +38,5 @@ class DDSCircleLayerTutorialViewController: UIViewController, MGLMapViewDelegate
         layer.circleRadius = NSExpression(format: "mgl_interpolate:withCurveType:parameters:stops:($zoomLevel, 'linear', nil, %@)", zoomStops)
 
         style.addLayer(layer)
-        // #-end-code-snippet: expressions add-layer-swift
     }
 }

--- a/DocsCode/FirstStepsTutorial/FirstStepsTutorialViewController.m
+++ b/DocsCode/FirstStepsTutorial/FirstStepsTutorialViewController.m
@@ -10,44 +10,31 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    // #-code-snippet: first-steps-ios-sdk initialize-map-objc
     MGLMapView *mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
     mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     [mapView setCenterCoordinate:CLLocationCoordinate2DMake(40.74699, -73.98742)
                        zoomLevel:9
                         animated:NO];
     [self.view addSubview:mapView];
-    // #-end-code-snippet: first-steps-ios-sdk initialize-map-objc
-    
-    // #-code-snippet: first-steps-ios-sdk change-style-objc
     mapView.styleURL = [MGLStyle satelliteStreetsStyleURL];
-    // #-end-code-snippet: first-steps-ios-sdk change-style-objc
-    
-    // #-code-snippet: first-steps-ios-sdk add-annotation-objc
+
     // Add a point annotation
     MGLPointAnnotation *annotation = [[MGLPointAnnotation alloc] init];
     annotation.coordinate = CLLocationCoordinate2DMake(40.77014, -73.97480);
     annotation.title = @"Central Park";
     annotation.subtitle = @"The best park in New York City!";
     [mapView addAnnotation:annotation];
-    // #-end-code-snippet: first-steps-ios-sdk add-annotation-objc
-    
-    // #-code-snippet: first-steps-ios-sdk show-location-objc
+
     // Allow the map view to display the user's location
     mapView.showsUserLocation = YES;
-    // #-end-code-snippet: first-steps-ios-sdk show-location-objc
-    
-    // #-code-snippet: first-steps-ios-sdk set-delegate-objc
+
     // Set the map view's delegate
     mapView.delegate = self;
-    // #-end-code-snippet: first-steps-ios-sdk set-delegate-objc
 }
 
-// #-code-snippet: first-steps-ios-sdk can-show-callout-objc
 - (BOOL)mapView:(MGLMapView *)mapView annotationCanShowCallout:(id<MGLAnnotation>)annotation {
     // Always allow callouts to popup when annotations are tapped.
     return YES;
 }
-// #-end-code-snippet: first-steps-ios-sdk can-show-callout-objc
 
 @end

--- a/DocsCode/FirstStepsTutorial/FirstStepsTutorialViewController.swift
+++ b/DocsCode/FirstStepsTutorial/FirstStepsTutorialViewController.swift
@@ -6,49 +6,35 @@ class FirstStepsTutorialViewController: UIViewController, MGLMapViewDelegate {
 
         super.viewDidLoad()
 
-        // #-code-snippet: first-steps-ios-sdk initialize-map-swift
         let mapView = MGLMapView(frame: view.bounds)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         mapView.setCenter(CLLocationCoordinate2D(latitude: 40.74699, longitude: -73.98742), zoomLevel: 9, animated: false)
         view.addSubview(mapView)
-        // #-end-code-snippet: first-steps-ios-sdk initialize-map-swift
 
-        // #-code-snippet: first-steps-ios-sdk change-style-swift
         mapView.styleURL = MGLStyle.satelliteStyleURL
-        // #-end-code-snippet: first-steps-ios-sdk change-style-swift
 
-        // #-code-snippet: first-steps-ios-sdk add-annotation-swift
         // Add a point annotation
         let annotation = MGLPointAnnotation()
         annotation.coordinate = CLLocationCoordinate2D(latitude: 40.77014, longitude: -73.97480)
         annotation.title = "Central Park"
         annotation.subtitle = "The biggest park in New York City!"
         mapView.addAnnotation(annotation)
-        // #-end-code-snippet: first-steps-ios-sdk add-annotation-swift
 
-        // #-code-snippet: first-steps-ios-sdk set-delegate-swift
         // Set the map view's delegate
         mapView.delegate = self
-        // #-end-code-snippet: first-steps-ios-sdk set-delegate-swift
 
-        // #-code-snippet: first-steps-ios-sdk show-location-swift
         // Allow the map view to display the user's location
         mapView.showsUserLocation = true
-        // #-end-code-snippet: first-steps-ios-sdk show-location-swift
     }
 
-    // #-code-snippet: first-steps-ios-sdk can-show-callout-swift
     func mapView(_ mapView: MGLMapView, annotationCanShowCallout annotation: MGLAnnotation) -> Bool {
         // Always allow callouts to popup when annotations are tapped.
         return true
     }
-    // #-end-code-snippet: first-steps-ios-sdk can-show-callout-swift
 
-    // #-code-snippet: first-steps-ios-sdk fly-to-annotation-swift
     func mapView(_ mapView: MGLMapView, didSelect annotation: MGLAnnotation) {
         let camera = MGLMapCamera(lookingAtCenter: annotation.coordinate, altitude: 4500, pitch: 15, heading: 180)
         mapView.fly(to: camera, withDuration: 4,
                     peakAltitude: 3000, completionHandler: nil)
     }
-    // #-end-code-snippet: first-steps-ios-sdk fly-to-annotation-swift
 }


### PR DESCRIPTION
We don't need these comments anymore. This PR removes them so the code we display in tutorials is cleaner. 💅 