### PR TITLE
Update links to reference "main" branch

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -7,7 +7,7 @@ These instructions are intended for internal Mapbox developers.
 ### Automatically on CI
 
 1. [Navigate to the `ios-sdk-examples` Bitrise project.](https://app.bitrise.io/app/9a144f2169b7c9e3)
-2. Manually start a new build on your desired branch (typically `ios-vX.X.X` or `master`) with the `testflight` workflow.
+2. Manually start a new build on your desired branch (typically `ios-vX.X.X` or `main`) with the `testflight` workflow.
 3. Wait for the build to complete and for the TestFlight upload to process.
 
 ### Manually

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mapbox iOS SDK Examples
 
-[![bitrise](https://app.bitrise.io/app/9a144f2169b7c9e3/status.svg?token=yzLGB24ubR_INs6HqUl14g&branch=master)](https://app.bitrise.io/app/9a144f2169b7c9e3#)[![codecov](https://codecov.io/gh/mapbox/ios-sdk-examples/branch/master/graph/badge.svg)](https://codecov.io/gh/mapbox/ios-sdk-examples)
+[![bitrise](https://app.bitrise.io/app/9a144f2169b7c9e3/status.svg?token=yzLGB24ubR_INs6HqUl14g&branch=main)](https://app.bitrise.io/app/9a144f2169b7c9e3#)[![codecov](https://codecov.io/gh/mapbox/ios-sdk-examples/branch/main/graph/badge.svg)](https://codecov.io/gh/mapbox/ios-sdk-examples)
 
 A live Xcode project/app that provides [public examples](https://www.mapbox.com/ios-sdk/examples/) for the Mapbox Maps SDK for iOS.
 


### PR DESCRIPTION
Edits some links to refer to the new `main` primary branch!